### PR TITLE
link to bmlt-enabled, spelling and add timezone api req. to google api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ cookie.txt
 *_cookie.txt
 config.php.*
 test.php
-
+/docs/.sass-cache/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: Yap
 description: Yap Documentation
 baseurl:
 url: "//yap.bmlt.app"
-remote_theme: "pmarsceill/just-the-docs", "~> 0.2.0"
+remote_theme: "bmlt-enabled/just-the-docs", "~> 0.2.0"
 sass:
   # Load dependancies
   load_paths:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: Yap
 description: Yap Documentation
 baseurl:
 url: "//yap.bmlt.app"
-remote_theme: "pmarsceill/just-the-docs"
+remote_theme: "pmarsceill/just-the-docs", "~> 0.2.0"
 sass:
   # Load dependancies
   load_paths:

--- a/docs/docs/general/setup.md
+++ b/docs/docs/general/setup.md
@@ -28,7 +28,7 @@ static $bmlt_username = "";
 static $bmlt_password = "";
 ```
 
-5. Be sure to get a Google Maps API key.  Specify this in config.php as the value for `$google_maps_api_key`.  Make sure you have "Google Maps Geocoding API" enabled on your credentials.  This key must be seperate from your BMLT key with no server restrictions, this is safe because yap never passes the key client side.  You can login into your Google API console here: https://console.cloud.google.com/apis/.  This article may be useful https://bmlt.magshare.net/google-maps-api-keys-and-geolocation-issues/.
+5. Be sure to get a Google Maps API key.  Specify this in config.php as the value for `$google_maps_api_key`.  Make sure you have "Google Maps Geocoding API" and "Google Maps Time Zone API" enabled on your credentials.  This key must be separate from your BMLT key with no server restrictions, this is safe because yap never passes the key client side.  You can login into your Google API console here: https://console.cloud.google.com/apis/.  This article may be useful https://bmlt.magshare.net/google-maps-api-keys-and-geolocation-issues/.
 
 6. Try testing that your application actually is functioning properly by opening a browser http://example.com/index.php.  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,4 +24,4 @@ We are taking advantage of using Twilio which essentially handles all the VOIP p
 
 {: .fs-6 .fw-300 }
 
-[View on GitHub](http://github.com/radius314/yap){: .btn .fs-5 }
+[View on GitHub](http://github.com/bmlt-enabled/yap){: .btn .fs-5 }


### PR DESCRIPTION
wondering if we can link yap.bmlt.app to bmlt-enabled/yap otherwise youll just have to make sure to try to keep your fork at radius314/yap up to date.