### PR TITLE
simply don't use remote theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: Yap
 description: Yap Documentation
 baseurl:
 url: "//yap.bmlt.app"
-remote_theme: "bmlt-enabled/just-the-docs"
+search_enabled: true
 sass:
   # Load dependancies
   load_paths:


### PR DESCRIPTION
the issue was we were trying to use a remote theme while including the whole theme. seems to me we have three options.
1. do this and have a easier test environment
2. use the external theme from theme developer and dump all files but the markdown ones, this would be simpler but make it harder for test environment.
3. I don't know do neither 1 or 2.

either option im fine with