### PR TITLE
get user name from get_user_info admin endpoint if exists

### DIFF
--- a/admin/home.php
+++ b/admin/home.php
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="col-md">
             <div class="jumbotron">
-                <h1 class="display-5"><?php echo word('welcome')?>, <?php echo $_SESSION['username']?>...</h1>
+                <h1 class="display-5"><?php echo word('welcome')?>, <?php echo admin_GetUserName()?>...</h1>
                 <p class="lead">Yap (<?php echo $GLOBALS['version']?>)</p>
                 <button class="btn btn-sm <?php echo $status['status'] ? "btn-success" : "btn-danger" ?>"
                         id="upgrade-advisor-details"

--- a/admin/nav.php
+++ b/admin/nav.php
@@ -28,7 +28,7 @@ require_once 'header.php';
                 <button type="button"
                         class="btn btn-danger"
                         id="log-out-button"
-                        onclick="location.href='logout.php';"><?php echo $GLOBALS['log_out']?> <?php echo $_SESSION['username']?></button>
+                        onclick="location.href='logout.php';"><?php echo $GLOBALS['log_out']?> <?php echo admin_GetUserName()?></button>
             </li>
         </ul>
     </div>

--- a/endpoints/functions.php
+++ b/endpoints/functions.php
@@ -679,6 +679,12 @@ function admin_PersistHelplineData($helpline_data_id = 0, $service_body_id, $dat
     return post($url, $data_bmlt_encoded, false, $_SESSION['username']);
 }
 
+function admin_GetUserName() {
+    $url = getHelplineBMLTRootServer() . "/local_server/server_admin/json.php?admin_action=get_user_info";
+    $user_name_info = json_decode(get($url, $_SESSION['username']))->current_user->name;
+    return $user_name_info ? $user_name_info : $_SESSION['username'];
+}
+
 function getAllHelplineData($data_type) {
     return getHelplineData(0, $data_type);
 }

--- a/endpoints/functions.php
+++ b/endpoints/functions.php
@@ -682,7 +682,7 @@ function admin_PersistHelplineData($helpline_data_id = 0, $service_body_id, $dat
 function admin_GetUserName() {
     $url = getHelplineBMLTRootServer() . "/local_server/server_admin/json.php?admin_action=get_user_info";
     $user_name_info = json_decode(get($url, $_SESSION['username']))->current_user->name;
-    return $user_name_info ? $user_name_info : $_SESSION['username'];
+    return isset($user_name_info) ? $user_name_info : $_SESSION['username'];
 }
 
 function getAllHelplineData($data_type) {


### PR DESCRIPTION
if the server supports the get_user_info request and name string is there, this will return the users name else it will just return the session user login.

ref root server [#124](https://github.com/bmlt-enabled/bmlt-root-server/issues/124)