### PR TITLE
fix for No map link on SMS #254

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,7 @@
 # Release Notes
+### 3.0.1 (UNRELEASED)
+* Fix for no map link being sent when using include map link option. [#254]
+
 ### 3.0.0 (March 23, 2019)
 * Call blasting which gives the ability to call all on shift volunteers simultaneously. [#60]
 * Language based call routing and volunteers.  This feature allow you to set up a list of volunteers that speak a particular language and route calls to them if that language is selected. [#146]

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -6,7 +6,7 @@ session_start();
 require_once(!getenv("ENVIRONMENT") ? __DIR__ . '/../../config.php' : __DIR__ . '/../../config.' . getenv("ENVIRONMENT") . '.php');
 require_once 'migrations.php';
 require_once 'logging.php';
-static $version  = "3.0.0";
+static $version  = "3.0.1";
 class VolunteerLanguage
 {
     const UNSPECIFIED = 0;

--- a/endpoints/meeting-search.php
+++ b/endpoints/meeting-search.php
@@ -94,7 +94,8 @@ if (has_setting('sms_summary_page') && json_decode(setting('sms_summary_page')))
     for ($i = 0; $i < count($filtered_list); $i++) {
         $results = getResultsString($filtered_list[$i]);
         $location_line = (has_setting('include_location_text') && json_decode(setting('include_location_text'))) ? $results[2] . $text_space . $results[3] : $results[3];
-        $message = $results[0] . $text_space . $results[1] . $text_space . $location_line;
+        $maplink_line = (has_setting('include_map_link') && json_decode(setting('include_map_link'))) ? $results[4] .= " https://google.com/maps?q=" . $filtered_list[$i]->latitude . "," . $filtered_list[$i]->longitude : $results[4];
+        $message = $results[0] . $text_space . $results[1] . $text_space . $location_line . $maplink_line;
 
         if (json_decode(setting("sms_ask")) && !isset($_REQUEST["SmsSid"])) {
             array_push($sms_messages, $message);


### PR DESCRIPTION
this must not have been merged back in after adding feature. not sure if this is how we want to fix it, but I have tested the following ways and works fine.
1. with include_map_link set but not include_location_text.
2. with include_location_text but not include_map_link set.
3. both include_map_link and include_location_text set.
4. neither include_location_text and include_map_link set.