### PR TITLE
fix for errors messaging landlines #171

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,8 @@
 # Release Notes
+### 3.0.3 (Unreleased)
+* Fix for overriden Twilio credentials that weren't being utilized.
+* Renamed "Add" to "Create" for creating new groups.
+
 ### 3.0.2 (April 4, 2019)
 * Added validation for URL fields in Calling Handling. [#228]
 * Added language file for Australian English to simplify configuration. [#252] [#253]

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -36,6 +36,7 @@ static $settings_whitelist = [
     'location_lookup_bias' => [ 'description' => '' , 'default' => 'country:us', 'overridable' => true, 'hidden' => false],
     'meeting_result_sort' => [ 'description' => '' , 'default' => MeetingResultSort::TODAY, 'overridable' => true, 'hidden' => false],
     'meeting_search_radius' => [ 'description' => '' , 'default' => -50, 'overridable' => true, 'hidden' => false],
+    'mobile_check' => [ 'description' => '' , 'default' => false, 'overridable' => true, 'hidden' => false],
     'postal_code_length' => [ 'description' => '' , 'default' => 5, 'overridable' => true, 'hidden' => false],
     'province_lookup' => [ 'description' => '' , 'default' => false, 'overridable' => true, 'hidden' => false],
     'result_count_max' => [ 'description' => '' , 'default' => 5, 'overridable' => true, 'hidden' => false],

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -6,7 +6,7 @@ session_start();
 require_once(!getenv("ENVIRONMENT") ? __DIR__ . '/../../config.php' : __DIR__ . '/../../config.' . getenv("ENVIRONMENT") . '.php');
 require_once 'migrations.php';
 require_once 'logging.php';
-static $version  = "3.0.2";
+static $version  = "3.0.3";
 class VolunteerLanguage
 {
     const UNSPECIFIED = 0;


### PR DESCRIPTION
this adds a mobile_check option, if this is set it will check if caller is mobile device and send txts. If not set it will continue to send txts regardless of device type.