### PR TITLE
calculate seconds, including minutes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 * Fix for non-working SMS volunteer routing [#274]
 * Fix for an edge case to render schedule ordering correctly [#162]
 * Data point added to upgrade-advisor for getting the git hash for each build for QA and Beta users.
+* Fix for duration not displaying properly on volunteer records.
 
 ### 3.1.0 (April 18, 2019)
 * Support for different voices for each languages [#260]

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,7 +5,7 @@
 * Fix for non-working SMS volunteer routing [#274]
 * Fix for an edge case to render schedule ordering correctly [#162]
 * Data point added to upgrade-advisor for getting the git hash for each build for QA and Beta users.
-* Fix for duration not displaying properly on volunteer records.
+* Fix for duration not displaying properly on volunteer records. [#275]
 
 ### 3.1.0 (April 18, 2019)
 * Support for different voices for each languages [#260]

--- a/admin/records.php
+++ b/admin/records.php
@@ -18,7 +18,7 @@ include_once '../endpoints/_includes/twilio-client.php';?>
                 $conference = $twilioClient->conferences($row['conferencesid'])->fetch();
                 $recordings = $participant->recordings->read();
                 $recordingUri = count($recordings) > 0 ? "<a href='https://api.twilio.com" . str_replace(".json", ".mp3", $recordings[0]->uri) . "' target='_blank'>Play</a>" : "";
-                $duration = $conference->dateCreated->diff($conference->dateUpdated)->s;
+                $duration = $conference->dateUpdated->getTimestamp() - $conference->dateCreated->getTimestamp();
                 echo "<tr><td>" . $row['conferencesid'] . "</td><td>$recordingUri</a></td><td>" . $duration . "</td><td>" . $row['callsid'] . "</td><td>$phone_number</td><td>$role</td><td>" . $row['timestamp'] . "</td></tr>";
             }
             $lastconferencesid = $row['conferencesid'];


### PR DESCRIPTION
The seconds on the Volunteer Records were only displaying the seconds of the call but not total seconds including minutes. So for instance if a call was 4 minutes and 42 seconds long on the Volunteer Records it would only display 42 seconds instead of 282 seconds. This will fix that as were just subtracting timestamps. 