### PR TITLE
fix for undefined index warning for is_mobile

### DIFF
--- a/endpoints/meeting-search.php
+++ b/endpoints/meeting-search.php
@@ -28,7 +28,7 @@ try {
 
 function mobileCheck()
 {
-    if (!$_SESSION['is_mobile']) {
+    if (!isset($_SESSION['is_mobile'])) {
         $is_mobile = true;
         if (has_setting('mobile_check') && json_decode(setting('mobile_check'))) {
             $phone_number = $GLOBALS['twilioClient']->lookups->v1->phoneNumbers($_REQUEST['From'])->fetch(array("type" => "carrier"));


### PR DESCRIPTION
Jonathan found this warning in sezf logs, this should fix that.
[Mon Apr 22 16:27:59.432718 2019] [php7:notice] [pid 17166] [client 54.234.92.61:58174] PHP Notice:  Undefined index: is_mobile in /var/www/bmlt/zonal-yap/endpoints/meeting-search.php on line 31, referer: https://bmlt.sezf.org/zonal-yap/address-lookup.php?SearchType=2&msg=Gather+End&Called=%2B15555551212&Digits=36303&ToState=&CallerCountry=US&Direction=inbound&CallerState=FL&ToZip=&CallSid=CA7995d7154blipityblahblah09e3dc&To=%2B15555551212&CallerZip=&ToCountry=US&FinishedOnKey=&ApiVersion=2010-04-01&CalledZip=&CalledCity=&CallStatus=in-progress&From=%2B15555551212&AccountSid=ACe31569da2blahblahblah9aa&CalledCountry=US&CallerCity=&Caller=%2B15555551212&FromCountry=US&ToCity=&FromCity=&CalledState=&FromZip=&FromState=FL