### PR TITLE
Expansion of tomato integration

### DIFF
--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -735,7 +735,7 @@ function getProvince()
 
 function helplineSearch($latitude, $longitude)
 {
-    $search_url = getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
+    $search_url = getHelplineBMLTRootServer($latitude, $longitude, SearchType::VOLUNTEERS) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
             $latitude, $longitude, setting('helpline_search_radius'), setting('call_routing_filter'));
 
     if (has_setting('helpline_search_unpublished') && json_decode(setting('helpline_search_unpublished'))) {
@@ -748,31 +748,41 @@ function helplineSearch($latitude, $longitude)
     return json_decode(get($search_url));
 }
 
-function getBMLTServer($latitude, $longitude, $search_type)
+function BMLTServerIsLocalConfig($latitude, $longitude)
 {
     $helpline_search_radius = setting('helpline_search_radius');
+    $bmlt_search_endpoint = setting('tomato_url') . "/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
+    $search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
+    $search_results = json_decode(get($search_url));
+    $pinged_BMLT_root = $search_results[0] -> root_server_uri;
+    $bmlt_root = $GLOBALS['bmlt_root_server']."/";
+    if ($pinged_BMLT_root == $bmlt_root) {
+        return true;
+    } else {
+    return false;
+    }
+}
+
+function getHelplineBMLTRootServer($latitude, $longitude, $search_type)
+{
     if ($search_type == SearchType::VOLUNTEERS) {
-        if (setting('tomato_helpline_fallback')) {
-            $bmlt_search_endpoint = setting('tomato_url') . "/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
-            $search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
-            $search_results = json_decode(get($search_url));
-            $pinged_BMLT_root = $search_results[0] -> root_server_uri;
-            $bmlt_root = $GLOBALS['bmlt_root_server']."/";
-            if ($pinged_BMLT_root != $bmlt_root) { // If the rootserver handling the phonecall is not the local rootserver, enable tomato routing - otherwise handle call routing locally.
-                $GLOBALS['settings_whitelist']['tomato_helpline_routing']['default'] = true;
-            }
-            return getHelplineBMLTRootServer();
-        } else {
-            return getHelplineBMLTRootServer();
-        }
-    } else if ($search_type == SearchType::MEETINGS) {
-        if (setting('tomato_meeting_search')) {
+        if (setting('tomato_helpline_fallback') & !BMLTServerIsLocalConfig($latitude, $longitude)) {
             return setting('tomato_url');
+        }
+    } else if (($search_type == SearchType::MEETINGS) && setting('tomato_meeting_search')) {
+        return setting('tomato_url');
         } else {
             return $GLOBALS['bmlt_root_server'];
         }
-    }
-}	
+
+    if (json_decode(setting('tomato_helpline_routing'))) {
+            return setting('tomato_url');
+        } else if (has_setting('helpline_bmlt_root_server')) {
+            return setting('helpline_bmlt_root_server');
+        } else {
+            return $GLOBALS['bmlt_root_server'];
+        }
+}
 
 function getFormatString($formats, $ignore = false, $helpline = false)
 {
@@ -787,7 +797,7 @@ function getFormatString($formats, $ignore = false, $helpline = false)
 
 function meetingSearch($meeting_results, $latitude, $longitude, $day)
 {
-    $bmlt_base_url = getBMLTServer($latitude, $longitude, SearchType::MEETINGS) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
+    $bmlt_base_url = getHelplineBMLTRootServer($latitude, $longitude, SearchType::MEETINGS) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
     $bmlt_search_endpoint = setting('custom_query');
     if (has_setting('ignore_formats')) {
         $bmlt_search_endpoint .= getFormatString(setting('ignore_formats'), true);
@@ -855,10 +865,8 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-    getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS);
-	
     $search_results = helplineSearch($latitude, $longitude);
-    $service_bodies = getServiceBodies();
+    $service_bodies = getServiceBodies($latitude, $longitude, SearchType::VOLUNTEERS);
     $already_checked = [];
 
     // Must do this because the BMLT returns an empty object instead of an empty array.
@@ -954,9 +962,9 @@ function getNextMeetingInstance($meeting_day, $meeting_time)
     return $mod_meeting_datetime;
 }
 
-function getServiceBodies()
+function getServiceBodies($latitude, $longitude, $search_type)
 {
-    $bmlt_search_endpoint = getHelplineBMLTRootServer() . "/client_interface/json/?switcher=GetServiceBodies";
+    $bmlt_search_endpoint = getHelplineBMLTRootServer($latitude, $longitude, $search_type) . "/client_interface/json/?switcher=GetServiceBodies";
     return json_decode(get($bmlt_search_endpoint));
 }
 
@@ -1469,17 +1477,6 @@ function sort_on_field(&$objects, $on, $order = 'ASC')
     usort($objects, function ($a, $b) use ($on, $order) {
         return $order === 'DESC' ? -strcoll($a->{$on}, $b->{$on}) : strcoll($a->{$on}, $b->{$on});
     });
-}
-
-function getHelplineBMLTRootServer()
-{
-    if (json_decode(setting('tomato_helpline_routing'))) {
-        return setting('tomato_url');
-    } else if (has_setting('helpline_bmlt_root_server')) {
-        return setting('helpline_bmlt_root_server');
-    } else {
-        return $GLOBALS['bmlt_root_server'];
-    }
 }
 
 function getCookiePath($cookieName)

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -51,6 +51,8 @@ static $settings_whitelist = [
     'toll_province_bias' => [ 'description' => '' , 'default' => null, 'overridable' => true, 'hidden' => false],
     'toll_free_province_bias' => [ 'description' => '' , 'default' => '', 'overridable' => true, 'hidden' => false],
     'tomato_helpline_routing' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
+	'tomato_helpline_fallback' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
+	'tomato_meeting_search' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
     'tomato_url' => [ 'description' => '' , 'default' => 'https://tomato.bmltenabled.org/main_server', 'overridable' => true, 'hidden' => false],
     'twilio_account_sid' => [ 'description' => '', 'default' => '', 'overridable' => true, 'hidden' => true],
     'twilio_auth_token' => [ 'description' => '', 'default' => '', 'overridable' => true, 'hidden' => true],
@@ -733,7 +735,7 @@ function getProvince()
 
 function helplineSearch($latitude, $longitude)
 {
-    $search_url = getHelplineBMLTRootServer() . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
+    $search_url = getBMLTserver($latitude, $longitude, 1) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
             $latitude, $longitude, setting('helpline_search_radius'), setting('call_routing_filter'));
 
     if (has_setting('helpline_search_unpublished') && json_decode(setting('helpline_search_unpublished'))) {
@@ -745,6 +747,30 @@ function helplineSearch($latitude, $longitude)
 
     return json_decode(get($search_url));
 }
+
+function getBMLTserver($latitude, $longitude, $search_state)
+{
+	$helpline_search_radius=setting('helpline_search_radius');
+	if ($search_state=="1") {
+		if (setting('tomato_helpline_fallback')) {
+			$bmlt_search_endpoint=setting('tomato_url')."/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
+			$search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
+			$search_results=json_decode(get($search_url));
+			$pinged_BMLT_root=$search_results[0]->root_server_uri;
+			$bmlt_root=$GLOBALS['bmlt_root_server']."/";
+			if($pinged_BMLT_root!=$bmlt_root) { // If the rootserver handling the phonecall is not the local rootserver, enable tomato routing - otherwise handle call routing locally.
+				$GLOBALS['settings_whitelist']['tomato_helpline_routing']['default']=true;
+				} 			
+		}
+	} else if ($search_state=="2") {
+			if (setting('tomato_meeting_search')) {
+				return setting('tomato_url');
+			} else {
+				return $GLOBALS['bmlt_root_server'];
+			}
+		}
+	return getHelplineBMLTRootServer();
+}	
 
 function getFormatString($formats, $ignore = false, $helpline = false)
 {
@@ -759,7 +785,7 @@ function getFormatString($formats, $ignore = false, $helpline = false)
 
 function meetingSearch($meeting_results, $latitude, $longitude, $day)
 {
-    $bmlt_base_url = $GLOBALS['bmlt_root_server'] . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
+    $bmlt_base_url = getBMLTserver($latitude, $longitude, 2) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
     $bmlt_search_endpoint = setting('custom_query');
     if (has_setting('ignore_formats')) {
         $bmlt_search_endpoint .= getFormatString(setting('ignore_formats'), true);
@@ -827,7 +853,8 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-    $search_results = helplineSearch($latitude, $longitude);
+	getBMLTserver($latitude, $longitude, 1);
+	$search_results = helplineSearch($latitude, $longitude);
     $service_bodies = getServiceBodies();
     $already_checked = [];
 

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 if (isset($_GET["ysk"])) {
     session_id($_GET["ysk"]);
 }
@@ -51,8 +51,8 @@ static $settings_whitelist = [
     'toll_province_bias' => [ 'description' => '' , 'default' => null, 'overridable' => true, 'hidden' => false],
     'toll_free_province_bias' => [ 'description' => '' , 'default' => '', 'overridable' => true, 'hidden' => false],
     'tomato_helpline_routing' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
-	'tomato_helpline_fallback' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
-	'tomato_meeting_search' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
+    'tomato_helpline_fallback' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
+    'tomato_meeting_search' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
     'tomato_url' => [ 'description' => '' , 'default' => 'https://tomato.bmltenabled.org/main_server', 'overridable' => true, 'hidden' => false],
     'twilio_account_sid' => [ 'description' => '', 'default' => '', 'overridable' => true, 'hidden' => true],
     'twilio_auth_token' => [ 'description' => '', 'default' => '', 'overridable' => true, 'hidden' => true],
@@ -735,7 +735,7 @@ function getProvince()
 
 function helplineSearch($latitude, $longitude)
 {
-    $search_url = getBMLTserver($latitude, $longitude, 1) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
+    $search_url = getBMLTServer($latitude, $longitude, SearchType:::VOLUNTEERS) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
             $latitude, $longitude, setting('helpline_search_radius'), setting('call_routing_filter'));
 
     if (has_setting('helpline_search_unpublished') && json_decode(setting('helpline_search_unpublished'))) {
@@ -748,28 +748,30 @@ function helplineSearch($latitude, $longitude)
     return json_decode(get($search_url));
 }
 
-function getBMLTserver($latitude, $longitude, $search_state)
+function getBMLTServer($latitude, $longitude, $search_type)
 {
-	$helpline_search_radius=setting('helpline_search_radius');
-	if ($search_state=="1") {
-		if (setting('tomato_helpline_fallback')) {
-			$bmlt_search_endpoint=setting('tomato_url')."/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
-			$search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
-			$search_results=json_decode(get($search_url));
-			$pinged_BMLT_root=$search_results[0]->root_server_uri;
-			$bmlt_root=$GLOBALS['bmlt_root_server']."/";
-			if($pinged_BMLT_root!=$bmlt_root) { // If the rootserver handling the phonecall is not the local rootserver, enable tomato routing - otherwise handle call routing locally.
-				$GLOBALS['settings_whitelist']['tomato_helpline_routing']['default']=true;
-				} 			
-		}
-	} else if ($search_state=="2") {
-			if (setting('tomato_meeting_search')) {
-				return setting('tomato_url');
-			} else {
-				return $GLOBALS['bmlt_root_server'];
-			}
-		}
-	return getHelplineBMLTRootServer();
+    $helpline_search_radius = setting('helpline_search_radius');
+    if ($search_type == SearchType:::VOLUNTEERS) {
+        if (setting('tomato_helpline_fallback')) {
+            $bmlt_search_endpoint = setting('tomato_url') . "/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
+            $search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
+            $search_results = json_decode(get($search_url));
+            $pinged_BMLT_root = $search_results[0] -> root_server_uri;
+            $bmlt_root = $GLOBALS['bmlt_root_server']."/";
+            if ($pinged_BMLT_root != $bmlt_root) { // If the rootserver handling the phonecall is not the local rootserver, enable tomato routing - otherwise handle call routing locally.
+                $GLOBALS['settings_whitelist']['tomato_helpline_routing']['default'] = true;
+            }
+            return getHelplineBMLTRootServer();
+        } else {
+            return getHelplineBMLTRootServer();
+        }
+    } else if ($search_type == SearchType:::MEETINGS) {
+        if (setting('tomato_meeting_search')) {
+            return setting('tomato_url');
+        } else {
+            return $GLOBALS['bmlt_root_server'];
+        }
+    }
 }	
 
 function getFormatString($formats, $ignore = false, $helpline = false)
@@ -785,7 +787,7 @@ function getFormatString($formats, $ignore = false, $helpline = false)
 
 function meetingSearch($meeting_results, $latitude, $longitude, $day)
 {
-    $bmlt_base_url = getBMLTserver($latitude, $longitude, 2) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
+    $bmlt_base_url = getBMLTServer($latitude, $longitude, SearchType:::MEETINGS) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
     $bmlt_search_endpoint = setting('custom_query');
     if (has_setting('ignore_formats')) {
         $bmlt_search_endpoint .= getFormatString(setting('ignore_formats'), true);
@@ -853,8 +855,9 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-	getBMLTserver($latitude, $longitude, 1);
-	$search_results = helplineSearch($latitude, $longitude);
+    getBMLTServer($latitude, $longitude, SearchType:::VOLUNTEERS);
+	
+    $search_results = helplineSearch($latitude, $longitude);
     $service_bodies = getServiceBodies();
     $already_checked = [];
 

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -735,7 +735,7 @@ function getProvince()
 
 function helplineSearch($latitude, $longitude)
 {
-    $search_url = getBMLTServer($latitude, $longitude, SearchType:::VOLUNTEERS) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
+    $search_url = getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS) . sprintf("/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
             $latitude, $longitude, setting('helpline_search_radius'), setting('call_routing_filter'));
 
     if (has_setting('helpline_search_unpublished') && json_decode(setting('helpline_search_unpublished'))) {
@@ -751,7 +751,7 @@ function helplineSearch($latitude, $longitude)
 function getBMLTServer($latitude, $longitude, $search_type)
 {
     $helpline_search_radius = setting('helpline_search_radius');
-    if ($search_type == SearchType:::VOLUNTEERS) {
+    if ($search_type == SearchType::VOLUNTEERS) {
         if (setting('tomato_helpline_fallback')) {
             $bmlt_search_endpoint = setting('tomato_url') . "/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
             $search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
@@ -765,7 +765,7 @@ function getBMLTServer($latitude, $longitude, $search_type)
         } else {
             return getHelplineBMLTRootServer();
         }
-    } else if ($search_type == SearchType:::MEETINGS) {
+    } else if ($search_type == SearchType::MEETINGS) {
         if (setting('tomato_meeting_search')) {
             return setting('tomato_url');
         } else {
@@ -787,7 +787,7 @@ function getFormatString($formats, $ignore = false, $helpline = false)
 
 function meetingSearch($meeting_results, $latitude, $longitude, $day)
 {
-    $bmlt_base_url = getBMLTServer($latitude, $longitude, SearchType:::MEETINGS) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
+    $bmlt_base_url = getBMLTServer($latitude, $longitude, SearchType::MEETINGS) . "/client_interface/json/?switcher=GetSearchResults&data_field_key=meeting_name,weekday_tinyint,start_time,location_text,location_info,location_municipality,location_province,location_street,longitude,latitude,distance_in_miles,distance_in_km";
     $bmlt_search_endpoint = setting('custom_query');
     if (has_setting('ignore_formats')) {
         $bmlt_search_endpoint .= getFormatString(setting('ignore_formats'), true);
@@ -855,7 +855,7 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-    getBMLTServer($latitude, $longitude, SearchType:::VOLUNTEERS);
+    getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS);
 	
     $search_results = helplineSearch($latitude, $longitude);
     $service_bodies = getServiceBodies();


### PR DESCRIPTION
Adds ability to use tomato for helpline and meeting search without breaking admin or local YAP routing.

New config settings :
tomato_helpline_fallback
tomato_meeting_search

Both false by default