### PR TITLE
Tomato routing update

### DIFF
--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -770,7 +770,7 @@ function getBMLTRootServer()
 function getBMLTServer($latitude, $longitude, $search_type)
 {
     $helpline_search_radius = setting('helpline_search_radius');
-    if ($search_type == SearchType:::VOLUNTEERS) {
+    if ($search_type == SearchType::VOLUNTEERS) {
         if (setting('tomato_helpline_fallback')) {
             $bmlt_search_endpoint = setting('tomato_url') . "/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val={LONGITUDE}&lat_val={LATITUDE}&geo_width=" . $helpline_search_radius;
             $search_url = str_replace("{LONGITUDE}", $longitude, str_replace("{LATITUDE}", $latitude, $bmlt_search_endpoint));
@@ -784,7 +784,7 @@ function getBMLTServer($latitude, $longitude, $search_type)
         } else {
             return getHelplineBMLTRootServer();
         }
-    } else if ($search_type == SearchType:::MEETINGS) {
+    } else if ($search_type == SearchType::MEETINGS) {
         if (setting('tomato_meeting_search')) {
             return setting('tomato_url');
         } else {
@@ -874,12 +874,7 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-    getBMLTServer($latitude, $longitude, SearchType:::VOLUNTEERS);
-    $search_results = helplineSearch($latitude, $longitude);
-    $service_bodies = getServiceBodiesForRouting($latitude, $longitude);
-	$search_results = helplineSearch($latitude, $longitude);
-
-	
+    getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS);
     $search_results = helplineSearch($latitude, $longitude);
     $service_bodies = getServiceBodies();
     $already_checked = [];

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -730,40 +730,8 @@ function helplineSearch($latitude, $longitude)
 {
     $search_url = sprintf("%s/client_interface/json/?switcher=GetSearchResults&data_field_key=longitude,latitude,service_body_bigint&sort_results_by_distance=1&lat_val=%s&long_val=%s&geo_width=%s%s",
         getHelplineRoutingBMLTServer($latitude, $longitude), $latitude, $longitude, setting('helpline_search_radius'), setting('call_routing_filter'));
+
     return json_decode(get($search_url));
-}
-
-function isBMLTServerOwned($latitude, $longitude)
-{
-    $bmlt_search_endpoint = sprintf('%s/client_interface/json/?switcher=GetSearchResults&data_field_key=root_server_uri&sort_results_by_distance=1&long_val=%s&lat_val=%s&geo_width=%s',
-        setting('tomato_url'), $latitude, $longitude, setting('helpline_search_radius'));
-    $search_results = json_decode(get($bmlt_search_endpoint));
-    $root_server_uri_from_first_result = $search_results[0]->root_server_uri;
-    return strpos(getAdminBMLTRootServer(), $root_server_uri_from_first_result) == 0;
-}
-
-function getHelplineRoutingBMLTServer($latitude, $longitude) {
-    if (setting('tomato_helpline_routing') & !isBMLTServerOwned($latitude, $longitude)) {
-        return setting('tomato_url');
-    } else if (has_setting('helpline_bmlt_root_server')) {
-        return setting('helpline_bmlt_root_server');
-    } else {
-        return setting('bmlt_root_server');
-    }
-}
-
-function getAdminBMLTRootServer()
-{
-    if (has_setting('helpline_bmlt_root_server')) {
-        return setting('helpline_bmlt_root_server');
-    } else {
-        return setting('bmlt_root_server');
-    }
-}
-
-function getBMLTRootServer()
-{
-    return setting('bmlt_root_server');
 }
 
 function isBMLTServerOwned($latitude, $longitude)
@@ -882,7 +850,6 @@ function getResultsString($filtered_list)
 
 function getServiceBodyCoverage($latitude, $longitude)
 {
-    getBMLTServer($latitude, $longitude, SearchType::VOLUNTEERS);
     $search_results = helplineSearch($latitude, $longitude);
     $service_bodies = getServiceBodiesForRouting($latitude, $longitude);
     $already_checked = [];

--- a/endpoints/helpline-search.php
+++ b/endpoints/helpline-search.php
@@ -55,9 +55,7 @@ if (!isset($_REQUEST['ForceNumber'])) {
     $extension = isset($exploded_result[1]) ? $exploded_result[1] : "w";
     $service_body_id = isset($service_body_obj) ? $service_body_obj->id : 0;
 
-if (!setting("tomato_helpline_routing") && !isset($_REQUEST['ForceNumber'])) {
     $serviceBodyCallHandling = getServiceBodyCallHandling($service_body_id);
-}
 
 insertCallEventRecord(EventId::VOLUNTEER_SEARCH,
     (object)['gather' => $address, 'coordinates' => isset($coordinates) ? $coordinates : null]);


### PR DESCRIPTION
Fixed lat/long mismatch in isBMLTServerOwned

Changed compare method in isBMLTServerOwned

Changed getHelplineRoutingBMLTServer to check for tomato conditions, return tomato and in all other cases use getAdminBMLTRootServer - did this to break down conditions when tracking down

Added check for tomato_helpline_routing in getBMLTRootServer - fixed issue of unable to use tomato for meeting search

simplified getHelplineRoutingBMLTServer since getAdminBMLTRootServer performs the same listed function - no real functional change

Changed check_auth to reference getAdminBMLTRootServer for the admin panel

Admin, meeting search, helpline routing all accurate - except now when going to a YAP volunteer setup, it fails to call any volunteers and sits on indefinite hold