### PR TITLE
Fix auto getProvince on SMS Gateway

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,14 @@
 ### 3.6.1 (January 5, 2019)
 * Fix for null coordinate responses in map data. [#363]
 * Fix for service body name in reports.
+* Added simple check for state/province in SMS meeting search. [#367]
+
+### 3.6.0 (January 4, 2020)
+* Added favicon.
+* Added mapping of call events with POI CSV downloads. [#353]
+### 3.6.1 (January 5, 2019)
+* Fix for null coordinate responses in map data. [#363]
+* Fix for service body name in reports.
 
 ### 3.6.0 (January 4, 2020)
 * Added favicon.

--- a/endpoints/sms-gateway.php
+++ b/endpoints/sms-gateway.php
@@ -5,7 +5,11 @@ header("content-type: text/xml");
 echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 
 $address = $_REQUEST['Body'];
-$coordinates = getCoordinatesForAddress($address . "," . getProvince());
+if (str_exists(substr($address, -4), ',')) {
+    $coordinates = getCoordinatesForAddress($address);
+} else {
+    $coordinates = getCoordinatesForAddress($address . "," . getProvince());
+}
 ?>
 <Response>
 <?php

--- a/yap.iml
+++ b/yap.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/yap.iml
+++ b/yap.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
sms-gateway had no check for someone putting in a state or province code which caused a bad search - i.e. Columbus, OH was being searched as Columbus, OH, NY and returning meetings from Tomato for New York, NY. Added a check for a , in the last 4 string positions of the address.