### PR TITLE
Optionally suppress voice results for meeting searches

### DIFF
--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -51,6 +51,7 @@ static $settings_whitelist = [
     'sms_helpline_keyword' => ['description' => '', 'default' => 'talk', 'overridable' => true, 'hidden' => false],
     'sms_summary_page' => ['description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
     'speech_gathering' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
+    'suppress_voice_results' => [ 'description' => '', 'default' => false, 'overridable' => true, 'hidden' => false],
     'time_format' => ['description' => '', 'default' => 'g:i A', 'overridable' => true, 'hidden' => false],
     'title' => [ 'description' => '' , 'default' => '', 'overridable' => true, 'hidden' => false],
     'toll_province_bias' => [ 'description' => '' , 'default' => null, 'overridable' => true, 'hidden' => false],

--- a/endpoints/meeting-search.php
+++ b/endpoints/meeting-search.php
@@ -9,6 +9,7 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
     $longitude = isset($_REQUEST['Longitude']) ? $_REQUEST['Longitude'] : null;
 
 try {
+    $suppress_voice_results = has_setting('suppress_voice_results') && json_decode(setting('suppress_voice_results'));
     $results_count = has_setting('result_count_max') ? intval(setting('result_count_max')) : 5;
     $meeting_results = getMeetings($latitude, $longitude, $results_count, null, null);
     $results_count_num = count($meeting_results->filteredList) < $results_count ? count($meeting_results->filteredList) : $results_count;
@@ -58,6 +59,8 @@ if (!$isFromSmsGateway) {
         echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . word('no_results_found') . "... " . word('you_might_have_invalid_entry') . "... " . word('try_again') . "</Say><Redirect method=\"GET\">input-method.php?Digits=2</Redirect>";
     } elseif (count($filtered_list) == 0) {
         echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . word('there_are_no_other_meetings_for_today') . ".... " . word('try_again') . "</Say><Redirect method=\"GET\">input-method.php?Digits=2</Redirect>";
+    } elseif ($suppress_voice_results) {
+        echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . $results_count_num  . " " . word('meetings_have_been_texted') . "</Say>";
     } else {
         echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . word('meeting_information_found_listing_the_top') . " " . $results_count_num . " " . word('results') . "</Say>";
     }
@@ -69,11 +72,11 @@ if (!$isFromSmsGateway) {
     }
 }
 
-    $results_counter = 0;
+$results_counter = 0;
 for ($i = 0; $i < count($filtered_list); $i++) {
     $results = getResultsString($filtered_list[$i]);
 
-    if (!$isFromSmsGateway) {
+    if (!$isFromSmsGateway && !$suppress_voice_results) {
         echo "<Pause length=\"1\"/>";
         echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . word('number') . " " . ($results_counter + 1) . "</Say>";
         echo "<Say voice=\"" . voice() . "\" language=\"" . setting('language') . "\">" . $results[0] . "</Say>";
@@ -154,7 +157,7 @@ if (has_setting('sms_summary_page') && json_decode(setting('sms_summary_page')))
     // Do not handle for the SMS gateway
 if (!$isFromSmsGateway && count($filtered_list) > 0) {
     echo "<Pause length=\"2\"/>";
-    if (count($sms_messages) > 0) { ?>
+    if (!$suppress_voice_results && count($sms_messages) > 0) { ?>
             <Gather numDigits="1" timeout="10" speechTimeout="auto" input="<?php echo getInputType() ?>"
                     action="post-call-action.php?Payload=<?php echo urlencode(json_encode($sms_messages)) ?>"
                     method="GET">

--- a/lang/en-AU.php
+++ b/lang/en-AU.php
@@ -100,3 +100,4 @@ $edit = "Edit";
 $delete = "Delete";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/en-US.php
+++ b/lang/en-US.php
@@ -100,3 +100,4 @@ $edit = "Edit";
 $delete = "Delete";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/es-US.php
+++ b/lang/es-US.php
@@ -101,3 +101,4 @@ $edit = "Edit";
 $delete = "Delete";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/fr-CA.php
+++ b/lang/fr-CA.php
@@ -100,3 +100,4 @@ $edit = "Edit";
 $delete = "Delete";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/it-IT.php
+++ b/lang/it-IT.php
@@ -100,3 +100,4 @@ $edit = "Edit";
 $delete = "Elimina";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/pig-latin.php
+++ b/lang/pig-latin.php
@@ -92,3 +92,4 @@ $edit = "editcray";
 $delete = "Eleteday";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";

--- a/lang/pt-BR.php
+++ b/lang/pt-BR.php
@@ -100,3 +100,4 @@ $edit = "Edit";
 $delete = "Delete";
 $voicemail = "Voicemail";
 $volunteer_has_already_joined_the_call_goodbye = "A volunteer has already joined the call... goodbye";
+$meetings_have_been_texted = "meetings have been texted to you";


### PR DESCRIPTION
Admittedly, I am not sure if this is the best way to do this. The goal is to prevent virtual meeting results from being played back over the phone, and instead just informing the caller that the results have been texted to them. This code is currently live on the north star meeting finder.