### PR TITLE
fix encoding issues for jft

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ### 3.7.0 (UNRELEASED)
+* Fixed encoding issues with JFT. [#414]
 * Introducing Yap installer. [#373]
 * Added custom extensions feature that allows for setting up arbitrary call forwards and/or prompt playbacks. (https://github.com/bmlt-enabled/yap/wiki/Custom-Extensions) [#355]
 * Added an option to combine SMS messages into a single SMS versus individual ones.

--- a/endpoints/_includes/functions.php
+++ b/endpoints/_includes/functions.php
@@ -1789,7 +1789,7 @@ function get_jft($sms = false)
 
     $jft = new DOMDocument;
     libxml_use_internal_errors(true);
-    $d->loadHTML(get($url));
+    $d->loadHTML(mb_convert_encoding(get($url), 'HTML-ENTITIES', 'UTF-8'));
     libxml_clear_errors();
     libxml_use_internal_errors(false);
     $xpath = new DOMXpath($d);


### PR DESCRIPTION
jft is not working today, theres an evil black diamond replacement character. https://jftna.org/jft/  this will fix any encoding issues with any of the languages and is what i do for the fetch-jft plugin.