### PR TITLE
safely parse legacy data for bmlt 3

### DIFF
--- a/legacy/_includes/legacydata.php
+++ b/legacy/_includes/legacydata.php
@@ -12,7 +12,8 @@ function getHelplineData($service_body_id, $data_type)
 
     if ($helpline_data != null) {
         foreach ($helpline_data as $item) {
-            $json_string = str_replace(';', ',', html_entity_decode(explode('#@-@#', $item->contact_phone_1)[2]));
+            $json_data = strpos($item->contact_phone_1, '#@-@#') !== false ? explode('#@-@#', $item->contact_phone_1)[2] : $item->contact_phone_1;
+            $json_string = str_replace(';', ',', html_entity_decode($json_data));
             array_push($helpline_data_items, [
                 'id'              => intval($item->id_bigint),
                 'data'            => json_decode($json_string)->data,

--- a/legacy/_includes/legacydata.php
+++ b/legacy/_includes/legacydata.php
@@ -1,5 +1,5 @@
 <?php
-$flag_setting = getFlag('root_server_data_migration');
+$flag_setting = 1; //getFlag('root_server_data_migration');
 
 function getHelplineData($service_body_id, $data_type)
 {

--- a/legacy/_includes/legacydata.php
+++ b/legacy/_includes/legacydata.php
@@ -1,5 +1,5 @@
 <?php
-$flag_setting = 1; //getFlag('root_server_data_migration');
+$flag_setting = getFlag('root_server_data_migration');
 
 function getHelplineData($service_body_id, $data_type)
 {


### PR DESCRIPTION
bmlt 3.0 is not gonna have the crazy `#@-@#` delimiters so trying to account for that