### PR TITLE
fix advisor link for login url

### DIFF
--- a/legacy/admin/status_control.php
+++ b/legacy/admin/status_control.php
@@ -5,7 +5,7 @@
    data-toggle="tooltip"
    data-placement="bottom"
    target="_blank"
-   href="../upgrade-advisor.php"
+   href="<?php echo url('/upgrade-advisor.php');  ?>"
    title="<?php echo $status['message']?>">
     <?php echo sprintf("Status: %s", ($status['status'] ? "OK" : "Problem")); ?>
 </a>


### PR DESCRIPTION
im sure theres a better fix for this but the status advisor link on sign in admin page is broken