### PR TITLE
added explicit notification that SMS will be sent in response to meeting search request

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 ### 4.3.0 (UNRELEASED)
 * Fix for scenario when `sms_combine` is enabled and `sms_ask` is disabled.  [#706]
+* Added explicit notification that SMS will be sent in response to meeting search request; reflected this in report. This is to satisfy regulatory requirements regarding explicit consent.
 
 ### 4.2.8 (December 28, 2022).
 * Fix for issue where SMS notifications wouldn't send for voicemails with Responder setting. [#709]

--- a/lang/en-AU.php
+++ b/lang/en-AU.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/lang/en-US.php
+++ b/lang/en-US.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/lang/es-US.php
+++ b/lang/es-US.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/lang/fr-CA.php
+++ b/lang/fr-CA.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/lang/it-IT.php
+++ b/lang/it-IT.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/lang/pig-latin.php
+++ b/lang/pig-latin.php
@@ -98,3 +98,4 @@ $GLOBALS['to_speak_to_a_man'] = "otay alktay otay ayay anmay";
 $GLOBALS['to_speak_to_a_woman'] = "otay alktay otay ayay omanway";
 $GLOBALS['speak_no_preference'] = "otay eakspay otay eitheryay";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "ouyay avehay anyay incomingyay onelinephay allcay omfray";
+$GLOBALS['search_results_by_sms'] = "eetingmay earchsay esultsray illway lsoay ebay entsay otay ouyay ybay SMS extay essagemay.";

--- a/lang/pt-BR.php
+++ b/lang/pt-BR.php
@@ -106,3 +106,4 @@ $GLOBALS['to_speak_to_a_man'] = "to talk to a man";
 $GLOBALS['to_speak_to_a_woman'] = "to talk to a woman";
 $GLOBALS['speak_no_preference'] = "to speak to either";
 $GLOBALS['you_have_an_incoming_phoneline_call_from'] = "You have an incoming phoneline call from";
+$GLOBALS['search_results_by_sms'] = "Meeting search results will also be sent to you by SMS text message.";

--- a/legacy/_includes/functions.php
+++ b/legacy/_includes/functions.php
@@ -218,7 +218,7 @@ class EventId
             case self::CALLER_HUP:
                 return "Caller Hungup";
             case self::MEETING_SEARCH_LOCATION_GATHERED:
-                return "Meeting Search Location Gathered";
+                return "Caller Consented to Receive SMS; Meeting Search Location Gathered";
             case self::HELPLINE_ROUTE:
                 return "Helpline Route";
             case self::VOICEMAIL_PLAYBACK:

--- a/legacy/input-method.php
+++ b/legacy/input-method.php
@@ -73,6 +73,12 @@ if (($searchType == SearchType::VOLUNTEERS || $searchType == SearchType::MEETING
             <Pause length="1"/>
         <?php }
 
+         if ($searchDescription == word('meetings') && !json_decode(setting("sms_ask")) && !json_decode(setting("sms_disable"))) { ?>
+            <Say voice="<?php echo voice(); ?>" language="<?php echo setting('language') ?>">
+                Meeting search results will also be sent to you by SMS text message.
+            </Say>
+        <?php }
+
         $locationSearchMethodSequence = getDigitMapSequence('digit_map_location_search_method');
         foreach ($locationSearchMethodSequence as $digit => $method) {
             if ($method == LocationSearchMethod::VOICE) { ?>

--- a/legacy/input-method.php
+++ b/legacy/input-method.php
@@ -73,7 +73,7 @@ if (($searchType == SearchType::VOLUNTEERS || $searchType == SearchType::MEETING
             <Pause length="1"/>
         <?php }
 
-         if ($searchDescription == word('meetings') && !json_decode(setting("sms_ask")) && !json_decode(setting("sms_disable"))) { ?>
+        if ($searchDescription == word('meetings') && !json_decode(setting("sms_ask")) && !json_decode(setting("sms_disable"))) { ?>
             <Say voice="<?php echo voice(); ?>" language="<?php echo setting('language') ?>">
                 Meeting search results will also be sent to you by SMS text message.
             </Say>

--- a/legacy/input-method.php
+++ b/legacy/input-method.php
@@ -75,7 +75,7 @@ if (($searchType == SearchType::VOLUNTEERS || $searchType == SearchType::MEETING
 
         if ($searchDescription == word('meetings') && !json_decode(setting("sms_ask")) && !json_decode(setting("sms_disable"))) { ?>
             <Say voice="<?php echo voice(); ?>" language="<?php echo setting('language') ?>">
-                Meeting search results will also be sent to you by SMS text message.
+                <?php echo word('search_results_by_sms') ?>
             </Say>
         <?php }
 

--- a/public/src/js/yap-core.js
+++ b/public/src/js/yap-core.js
@@ -55,7 +55,7 @@ function initReports(dataLoadedCallback) {
 
     var eventsTableColumns = [
         {title: "Event Time", field: "event_time", mutator: toCurrentTimezone},
-        {title: "Event", field: "event_name"},
+        {title: "Event", field: "event_name", formatter: "textarea"},
         {title: "Service Body Id", field: "service_body_id", mutator: function(id) {
             if (isNaN(id)) return id;
             var service_body = getServiceBodyById(id);


### PR DESCRIPTION
This is in response to the changes requested by Twilio to verify toll-free numbers for some service bodies (e.g. North Carolina Region).  It makes explicit that the caller will receive an SMS in response to a meeting search request in addition to having the results read. It also adds a note about consent in the reports column, which was also requested by Twilio.

The reports column is formatted to allow text wrapping, since otherwise the essential bit gets lopped off. It could be nice to make the whole report display wider.