### PR TITLE
fix example of pronunciation override, update documentation

### DIFF
--- a/docs/docs/meeting-search/pronunciations.md
+++ b/docs/docs/meeting-search/pronunciations.md
@@ -2,13 +2,13 @@
 
 ---
 
-Sometimes the speech result of meeting locations may not be accurate based off the voice's ability to say it.  You can override this by specifying the original word (`source`) and the new word (`target`)
+Sometimes meeting location names are mispronounced.  You can override this by specifying the original name (`source`) and a phonetically spelled version (`target`)
 
 Example:
 
 ```php
-static $pronunciations = [[
-    "source"=>"Yakima",
-    "target"=>"UkEEma"
-]];
+static $pronunciations = [
+    ["source"=>"Sequim", "target"=>"Skwim"],
+    ["source"=>"Yakima", "target"=>"Yak-ima"],
+];
 ```

--- a/tests/Feature/AddressLookupTest.php
+++ b/tests/Feature/AddressLookupTest.php
@@ -58,8 +58,8 @@ test('search by zip code for meeting information with speech text result with go
 test('search by zip code for meeting information with speech text result and pronunciation override with google api key', function ($method) {
     $settingsService = new SettingsService();
     $settingsService->set('pronunciations', [[
-        "source"=>"Yakima",
-        "target"=>"UkEEma"
+        "source"=>"Sequim",
+        "target"=>"Skwim"
     ]]);
     app()->instance(SettingsService::class, $settingsService);
     $response = $this->call(


### PR DESCRIPTION
For the pronunciation override feature, this adds a more straightforward example ("Sequim", pronounced "Skwim"), and fixes the phonetic spelling for Yakima.  (The phonetic spelling provided for Yakima isn't perfect but I couldn't find a better one.)

Merging this PR makes sense only after the issue  noted in the comments on #917 is fixed.