### PR TITLE
Add Twilio SHAKEN/STIR trusted calling support

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,9 @@
 # Release Notes
 
-### 4.5.0 (UNRELEASED)
+### 4.5.1 (UNRELEASED)
+* Added Twilio SHAKEN/STIR trusted calling support. CallToken is forwarded from inbound to outbound calls to maintain full attestation (Level A). StirVerstat is logged on inbound calls for observability. [#1560]
+
+### 4.5.0
 * Added new feature that allow for creating a custom prompt for language selection feature. [#1228]
 * Fix to add some missing translations for Spanish.
 * Fix for SMS + Email full translation for language selected by caller. [#1387]

--- a/src/app/Constants/EventId.php
+++ b/src/app/Constants/EventId.php
@@ -30,6 +30,7 @@ class EventId
     const VOLUNTEER_SEARCH_FORCE_DIALED = 25;
     const VOLUNTEER_NUMBER_BAD = 26;
     const VOLUNTEER_NUMBER_BUSY = 27;
+    const STIR_VERSTAT_RECEIVED = 28;
 
     public static function getEventById($id)
     {
@@ -88,6 +89,8 @@ class EventId
                 return "Volunteer Number is Bad";
             case self::VOLUNTEER_NUMBER_BUSY:
                 return "Volunteer Number is Busy";
+            case self::STIR_VERSTAT_RECEIVED:
+                return "STIR/SHAKEN Verification Status Received";
         }
     }
 }

--- a/src/app/Http/Controllers/CallFlowController.php
+++ b/src/app/Http/Controllers/CallFlowController.php
@@ -77,6 +77,14 @@ class CallFlowController extends Controller
             }
         }
 
+        // Log SHAKEN/STIR verification status if present
+        if ($request->has('StirVerstat')) {
+            $this->call->insertCallEventRecord(
+                EventId::STIR_VERSTAT_RECEIVED,
+                (object)['stir_verstat' => $request->get('StirVerstat')]
+            );
+        }
+
         $digit = $this->call->getDigitResponse($request, 'language_selections', 'Digits');
 
         $twiml = new VoiceResponse();

--- a/src/app/Http/Controllers/HelplineController.php
+++ b/src/app/Http/Controllers/HelplineController.php
@@ -466,6 +466,12 @@ class HelplineController extends Controller
             'originalCallerId'     => $original_caller_id
         );
 
+        // Add SHAKEN/STIR CallToken for authenticated call forwarding
+        $callToken = $this->call->getCallTokenForForwarding($serviceBodyCallHandling);
+        if ($callToken !== null) {
+            $config->options['callToken'] = $callToken;
+        }
+
         $config->voicemail_url = $this->getWebhookUrl($request) . '/voicemail.php?service_body_id='
             . $serviceBodyCallHandling->service_body_id . '&caller_id='
             . trim($config->options['callerId']) . $this->settings->getSessionLink();

--- a/src/app/Http/Middleware/CallSession.php
+++ b/src/app/Http/Middleware/CallSession.php
@@ -59,6 +59,14 @@ class CallSession
             $_SESSION['initial_webhook'] = str_replace("&", "&amp;", $webhook_array[count($webhook_array) - 1]);
         }
 
+        // Capture SHAKEN/STIR parameters from inbound call
+        if ($request->has('CallToken') && !isset($_SESSION['call_token'])) {
+            $_SESSION['call_token'] = $request->get('CallToken');
+        }
+        if ($request->has('StirVerstat') && !isset($_SESSION['stir_verstat'])) {
+            $_SESSION['stir_verstat'] = $request->get('StirVerstat');
+        }
+
         // Override specific values for the session
         foreach ($request->all() as $key => $value) {
             if (str_contains($key, "override_")) {

--- a/src/app/Services/CallService.php
+++ b/src/app/Services/CallService.php
@@ -120,6 +120,14 @@ class CallService extends Service
         }
     }
 
+    public function getCallTokenForForwarding($serviceBodyCallHandling): ?string
+    {
+        if ($serviceBodyCallHandling->forced_caller_id_enabled) {
+            return null;
+        }
+        return $_SESSION['call_token'] ?? null;
+    }
+
     public function getVoicemailMessage($callerSid, $callerId, $smsDialbackOptions, $serviceBodyName, $callerNumber, $recordingUrl) : string
     {
         $dialbackString = $this->getDialbackString($callerSid, $callerId, $smsDialbackOptions);

--- a/src/app/Services/SettingsService.php
+++ b/src/app/Services/SettingsService.php
@@ -11,7 +11,7 @@ use DateTimeZone;
 
 class SettingsService
 {
-    private string $version = "4.5.0";
+    private string $version = "4.5.1";
     private array $allowlist = [
         'announce_servicebody_volunteer_routing' => ['description' => '/helpline/announce_servicebody_volunteer_routing' , 'default' => false, 'overridable' => true, 'hidden' => false],
         'blocklist' => ['description' => '/general/blocklist' , 'default' => '', 'overridable' => true, 'hidden' => false],


### PR DESCRIPTION
Closes #1560

## Summary

Based on the `4.5.0` tag. The phone number status dashboard and test fixes will be cherry-picked to 5.0 separately.

- Capture `CallToken` and `StirVerstat` from inbound Twilio webhooks in session (`$_SESSION`)
- Pass `CallToken` through to outbound `calls->create()` when forwarding calls with the original caller's number, maintaining full SHAKEN/STIR attestation (Level A)
- Log `StirVerstat` as a call event on inbound calls for observability
- Add `STIR_VERSTAT_RECEIVED` event constant

## How it works

When Twilio delivers an inbound call, it includes `CallToken` (a signed token proving caller identity) and `StirVerstat` (the verification status). YAP now captures both in the session. When dialing out to a volunteer using the original caller's number as caller ID, the `CallToken` is passed to Twilio's API so the outbound leg receives full attestation. When using a forced caller ID, the token is correctly omitted (Twilio requires the From number to match the token).

This is a transparent improvement — no configuration changes needed. If `CallToken` is absent (non-US calls, unsupported carriers), behavior is identical to before.

## Test plan

- [ ] Verify with live Twilio US calls that `StirVerstat` events appear in call logs
- [ ] Verify outbound calls to volunteers pass `CallToken` and receive Level A attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)