### PR TITLE
Add explicit status=in-progress to Twilio conferences->read() (4.5.x)

### DIFF
--- a/src/app/Http/Controllers/CallFlowController.php
+++ b/src/app/Http/Controllers/CallFlowController.php
@@ -725,7 +725,7 @@ class CallFlowController extends Controller
         $twiml = new VoiceResponse();
         if ($request->get('Digits') == "1") {
             $conferences = $this->twilio->client()->conferences
-                ->read(array ("friendlyName" => $request->get('conference_name') ));
+                ->read(array ("friendlyName" => $request->get('conference_name'), "status" => "in-progress"));
             $participants = $this->twilio->client()->conferences($conferences[0]->sid)->participants->read();
 
             if (count($participants) == 2) {
@@ -765,7 +765,7 @@ class CallFlowController extends Controller
     public function helplineOutdialResponse(Request $request)
     {
         $conferences = $this->twilio->client()->conferences
-            ->read(array ("friendlyName" => $request->get('conference_name') ));
+            ->read(array ("friendlyName" => $request->get('conference_name'), "status" => "in-progress"));
         $participants = $this->twilio->client()->conferences($conferences[0]->sid)->participants->read();
 
         $twiml = new VoiceResponse();

--- a/src/app/Http/Controllers/HelplineController.php
+++ b/src/app/Http/Controllers/HelplineController.php
@@ -274,7 +274,7 @@ class HelplineController extends Controller
         for ($i = 0; $i < ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRIES; $i++) {
             $conferences = $this->twilio->client()
                 ->conferences
-                ->read(array("friendlyName" => $request->get('FriendlyName')));
+                ->read(array("friendlyName" => $request->get('FriendlyName'), "status" => "in-progress"));
 
             if ($i > 0) {
                 Log::debug("conferences eventual consistency issue, retry $i");
@@ -287,7 +287,7 @@ class HelplineController extends Controller
             sleep(0.5);
         }
 
-        if (count($conferences) > 0 && $conferences[0]->status != TwilioCallStatus::COMPLETED) {
+        if (count($conferences) > 0) {
             $sms_body = $this->settings->word('you_have_an_incoming_phoneline_call_from') . " ";
 
             if ($request->has('StatusCallbackEvent') && $request->get('StatusCallbackEvent') == 'participant-join' &&

--- a/src/app/Services/CallService.php
+++ b/src/app/Services/CallService.php
@@ -97,7 +97,7 @@ class CallService extends Service
 
     public function setConferenceParticipant($friendlyname, $callsid, $role): void
     {
-        $conferences = $this->twilio->client()->conferences->read(array ("friendlyName" => $friendlyname ));
+        $conferences = $this->twilio->client()->conferences->read(array ("friendlyName" => $friendlyname, "status" => "in-progress"));
         $conferencesid = $conferences[0]->sid;
         $this->reports->setConferenceParticipant($friendlyname, $conferencesid, $callsid, $role);
     }

--- a/src/tests/Feature/HelplineAnswerResponseTest.php
+++ b/src/tests/Feature/HelplineAnswerResponseTest.php
@@ -31,7 +31,7 @@ beforeEach(function () {
 
     // mocking TwilioRestClient->conferences->read()
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
-    $conferenceListMock->shouldReceive("read")->with(['friendlyName' => $this->conferenceName])
+    $conferenceListMock->shouldReceive("read")->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode('[{"sid":"'.$this->conferenceSid.'"}]'));
     $this->twilioClient->conferences = $conferenceListMock;
 });

--- a/src/tests/Feature/HelplineDialerTest.php
+++ b/src/tests/Feature/HelplineDialerTest.php
@@ -156,7 +156,7 @@ test('do nothing', function ($method) {
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode(
             '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
         ))
@@ -229,7 +229,7 @@ test('mark the caller as having entered the conference for reporting purposes', 
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode(
             '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
         ))
@@ -360,7 +360,7 @@ test('mark the caller as having entered the conference for reporting purposes, w
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode(
             '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
         ))
@@ -488,7 +488,7 @@ test('an invalid or busy outgoing call happens with linear and voicemail and one
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode(
             '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
         ))
@@ -647,7 +647,7 @@ test('an invalid or busy outgoing call happens with linear and voicemail and two
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode(
             '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
         ))
@@ -1003,7 +1003,7 @@ test('caller leaves the call', function ($method) {
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn([])
         ->times(ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRIES);
     $this->twilioClient->conferences = $conferenceListMock;
@@ -1039,7 +1039,7 @@ test('volunteer leave the call', function ($method) {
 
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
     $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName])
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn([])
         ->times(ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRIES);
     $this->twilioClient->conferences = $conferenceListMock;

--- a/src/tests/Feature/HelplineOutdialResponseTest.php
+++ b/src/tests/Feature/HelplineOutdialResponseTest.php
@@ -34,7 +34,7 @@ beforeEach(function () {
 
     // mocking TwilioRestClient->conferences->read()
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
-    $conferenceListMock->shouldReceive("read")->with(['friendlyName' => $this->conferenceName])
+    $conferenceListMock->shouldReceive("read")->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
         ->andReturn(json_decode('[{"sid":"'.$this->conferenceName.'"}]'));
     $this->twilioClient->conferences = $conferenceListMock;
 


### PR DESCRIPTION
## Summary
Twilio is changing the default behavior of the [Conference list endpoint](https://www.twilio.com/docs/voice/api/conference-resource) on **July 13, 2026**. The endpoint will return only `in-progress` conferences by default instead of conferences of all statuses; fetching completed conferences will require an explicit `Status=completed` filter.

All four yap callers of `->conferences->read(...)` look up a **live** conference by `friendlyName` (completed-call/reporting data comes from the local `conference_participants` table), so there's no breaking change. This PR is the optional cleanup the issue calls out:

- Adds explicit `"status" => "in-progress"` to all 4 `->read(...)` callers in `HelplineController`, `CallFlowController` (×2), and `CallService` — documented speedup and removes the implicit dependency on Twilio's default.
- Simplifies the now-effectively-dead `status != COMPLETED` check at `HelplineController.php:290` — with the filter applied, `read()` can never return a completed conference, so the second clause is unreachable.
- Widens test mocks in `HelplineDialerTest`, `HelplineAnswerResponseTest`, and `HelplineOutdialResponseTest` to match the new argument shape.

### Branch targeting
yap 5.0.0 is unreleased (currently `5.0.0-beta2` on `main`); most users are on the **4.5.1** line. The Twilio cutover is July 13, 2026 — too soon to rely on a 5.0.0 release, so this PR targets `4.5.x` following the existing backport convention from #1561 (`feature/yap-1560-twilio-shaken-stir-4.5`). A follow-up issue will track the same change on `main`.

Closes #1562 on the 4.5.x line.

## Test plan
- [x] Focused pest suites pass: `HelplineDialerTest`, `HelplineAnswerResponseTest`, `HelplineOutdialResponseTest` (48 tests, 194 assertions)
- [x] Related pest suites pass: `DialbackTest`, `ReportsApiTest`, `StatusCallbackTest`, `VoicemailCompleteTest` (82 tests, 1221 assertions)
- [x] All 4 `->read(...)` callers now include `"status" => "in-progress"` (verified via grep)
- [x] The unreachable `!= TwilioCallStatus::COMPLETED` clause is removed; other `TwilioCallStatus::COMPLETED` uses (CallStatus checks deeper in the function) remain
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 matrix

🐦‍⬛ Generated with Claude Code, orchestrated by Crow