### PR TITLE
Add SECURITY.md and document private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The yap maintainers take security seriously. If you believe you have found a
+security vulnerability in yap, please report it to us **privately**. Do **not**
+open a public GitHub issue, pull request, or discussion for a security problem.
+
+Please use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/bmlt-enabled/yap/security) of this
+   repository.
+2. Click **Report a vulnerability** to open a private security advisory that is
+   visible only to the maintainers.
+
+To help us triage the report quickly, please include as much of the following as
+you can:
+
+- A description of the vulnerability and its potential impact.
+- The version or branch affected (see [Supported Versions](#supported-versions)).
+- Steps to reproduce, or a proof of concept.
+- Any suggested remediation, if you have one.
+
+## Supported Versions
+
+Security fixes are provided for the following release lines:
+
+| Version             | Supported          |
+| ------------------- | ------------------ |
+| 5.0.x (development) | :white_check_mark: |
+| 4.5.x               | :white_check_mark: |
+| < 4.5               | :x:                |
+
+We recommend running the
+[latest release](https://github.com/bmlt-enabled/yap/releases/latest).
+
+## Response Process
+
+- We will acknowledge your report within **5 business days**.
+- We will work with you to understand and validate the issue.
+- We aim to provide a resolution or mitigation plan within **30 days**, depending
+  on the severity and complexity of the issue.
+- We follow a **coordinated-disclosure** process: please give us reasonable time to
+  release a fix before any public disclosure. Once a fix is available, we will
+  publish a [GitHub Security Advisory](https://github.com/bmlt-enabled/yap/security/advisories).
+
+## Credit
+
+We are happy to credit reporters in the published advisory. Let us know in your
+report whether you would like to be credited, and how you would like to be named.


### PR DESCRIPTION
Closes #1567

## Summary
Adds a `SECURITY.md` at the repo root so security researchers have a documented private channel. Prompted by an external report (`tonghuaroot`) that had no private channel and had to use a generic org address.

## What's included
- **Reporting a Vulnerability** — directs researchers to the Security tab → **Report a vulnerability** (GitHub Private Vulnerability Reporting); no public issues/PRs for security problems.
- **Supported Versions** — `5.0.x` (development / `main`) and `4.5.x` (latest stable) are supported; `< 4.5` is not.
- **Response Process** — ~5 business day acknowledgement, coordinated disclosure, fixes published as GitHub Security Advisories.
- **Credit** — reporters credited in the advisory on request.

## Related settings
- GitHub **Private Vulnerability Reporting** is now **enabled** on the repo (Settings → Code security), so the "Report a vulnerability" button is live in the Security tab.
- Targets `main` only — GitHub surfaces `SECURITY.md` from the default branch, so no `4.5.x` backport is needed.

After merge, the policy will appear at https://github.com/bmlt-enabled/yap/security/policy.