### PR TITLE
security: enforce Twilio webhook signature validation on all inbound routes

### DIFF
--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -16,6 +16,7 @@ use App\Http\Middleware\SessionKey;
 use App\Http\Middleware\SmsBlackhole;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
+use App\Http\Middleware\ValidateTwilioSignature;
 use App\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
 use Illuminate\Auth\Middleware\Authorize;
@@ -101,6 +102,7 @@ class Kernel extends HttpKernel
         'password.confirm' => RequirePassword::class,
         'signed' => ValidateSignature::class,
         'throttle' => ThrottleRequests::class,
+        'twilio.signature' => ValidateTwilioSignature::class,
         'verified' => EnsureEmailIsVerified::class,
     ];
 }

--- a/src/app/Http/Middleware/TrustProxies.php
+++ b/src/app/Http/Middleware/TrustProxies.php
@@ -10,9 +10,14 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
+     * Trust all forwarding proxies. yap is deployed behind an AWS ELB (whose
+     * IPs are dynamic) and is not directly reachable, so '*' is the setting
+     * Laravel documents for this topology. This lets $request->fullUrl()
+     * reflect the public scheme/host that Twilio signed its webhooks against.
+     *
      * @var array|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/src/app/Http/Middleware/ValidateTwilioSignature.php
+++ b/src/app/Http/Middleware/ValidateTwilioSignature.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\SettingsService;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Twilio\Security\RequestValidator;
+
+class ValidateTwilioSignature
+{
+    protected SettingsService $settings;
+
+    public function __construct(SettingsService $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * Verifies that the request actually originated from Twilio by validating
+     * the X-Twilio-Signature header against the request URL and body. Fails
+     * closed: if no auth token is configured, or the signature is missing or
+     * invalid, the request is rejected with HTTP 403.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        // Development-only bypass. Off by default, and only ever honored outside
+        // of production, so a misconfigured production deployment can never skip
+        // validation. Used by the test suite (see phpunit.xml).
+        $bypass = !app()->environment('production')
+            && config('twilio.disable_signature_validation', false);
+
+        if ($bypass) {
+            Log::warning('Twilio signature validation bypassed (non-production dev flag enabled)');
+            return $next($request);
+        }
+
+        $authToken = $this->settings->get('twilio_auth_token');
+
+        // Fail closed: with no auth token we cannot verify the signature, so the
+        // request is rejected rather than allowed through.
+        if (empty($authToken)) {
+            Log::warning('Twilio signature validation failed: no auth token configured', [
+                'ip' => $request->ip(),
+            ]);
+            return response('Forbidden', 403);
+        }
+
+        $validator = new RequestValidator($authToken);
+        $signature = $request->header('X-Twilio-Signature', '');
+
+        // Validate against the URL the framework resolved (honoring the trusted
+        // proxy configuration in TrustProxies), never raw client-supplied
+        // forwarding headers.
+        $url = $request->fullUrl();
+
+        // Twilio signs POST requests using the POST body params only; for GET the
+        // query string is already part of the URL.
+        $params = $request->isMethod('POST') ? $request->post() : [];
+
+        if (!$validator->validate($signature, $url, $params)) {
+            Log::warning('Invalid Twilio signature rejected', [
+                'url' => $url,
+                'ip' => $request->ip(),
+            ]);
+            return response('Forbidden', 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/config/twilio.php
+++ b/src/config/twilio.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Disable Twilio Signature Validation
+    |--------------------------------------------------------------------------
+    |
+    | Development/local ONLY escape hatch for the ValidateTwilioSignature
+    | middleware. It is off by default and is only honored outside of
+    | production (the middleware additionally gates on the environment), so
+    | enabling it can never weaken a production deployment.
+    |
+    */
+
+    'disable_signature_validation' => env('TWILIO_DISABLE_SIGNATURE_VALIDATION', false),
+
+];

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -25,6 +25,7 @@
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
     <server name="TELESCOPE_ENABLED" value="false"/>
+    <server name="TWILIO_DISABLE_SIGNATURE_VALIDATION" value="true"/>
   </php>
   <source>
     <include>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 
 $ext = '(\.php)?$';
 
+// --- Non-Twilio routes (admin portal, bots, MSR, health/version, widget) ---
 Route::get('/v1/session/delete', 'App\Http\Controllers\SessionController@delete');
 Route::get("/admin/auth/rights", 'App\Http\Controllers\AuthController@rights');
 Route::get("/admin/auth/logout", 'App\Http\Controllers\AuthController@logout');
@@ -21,75 +22,83 @@ Route::get("/bots/getServiceBodyCoverage", 'App\Http\Controllers\BotController@g
 Route::get("/msr/{latitude}/{longitude}", ['uses' => 'App\Http\Controllers\MeetingResultsController@index'])
     ->where(['latitude' => '.*', 'longitude' => '.*']);
 Route::delete("/admin/cache", 'App\Http\Controllers\AdminController@cacheClear');
-Route::match(array('GET', 'POST'), "/fetch-jft{ext}", 'App\Http\Controllers\ReadingController@jft')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/fetch-spad{ext}", 'App\Http\Controllers\ReadingController@spad')
-    ->where('ext', $ext);
 Route::match(array('GET', 'POST'), "/ping{ext}", 'App\Http\Controllers\PingController@index')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/", 'App\Http\Controllers\CallFlowController@index')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/info", 'App\Http\Controllers\CallFlowController@info')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/index{ext}", 'App\Http\Controllers\CallFlowController@index')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/input-method{ext}", 'App\Http\Controllers\CallFlowController@inputMethod')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/custom-ext{ext}", 'App\Http\Controllers\CallFlowController@customext')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/input-method-result{ext}", 'App\Http\Controllers\CallFlowController@inputMethodResult')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/zip-input{ext}", 'App\Http\Controllers\CallFlowController@zipinput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/city-or-county-voice-input{ext}", 'App\Http\Controllers\CallFlowController@cityorcountyinput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/service-body-ext-response{ext}", 'App\Http\Controllers\CallFlowController@servicebodyextresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/gender-routing-response{ext}", 'App\Http\Controllers\CallFlowController@genderroutingresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voice-input-result{ext}", 'App\Http\Controllers\CallFlowController@voiceinputresult')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/address-lookup{ext}", 'App\Http\Controllers\CallFlowController@addresslookup')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/playlist{ext}", 'App\Http\Controllers\CallFlowController@playlist')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/fallback{ext}", 'App\Http\Controllers\CallFlowController@fallback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/custom-ext-dialer{ext}", 'App\Http\Controllers\CallFlowController@customextdialer')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/dialback-dialer{ext}", 'App\Http\Controllers\CallFlowController@dialbackDialer')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/dialback{ext}", 'App\Http\Controllers\CallFlowController@dialback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/gender-routing{ext}", 'App\Http\Controllers\CallFlowController@genderrouting')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/province-lookup-list-response{ext}", 'App\Http\Controllers\CallFlowController@provincelookuplistresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/status{ext}", 'App\Http\Controllers\CallFlowController@statusCallback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voicemail-complete{ext}", 'App\Http\Controllers\VoicemailController@complete')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voicemail{ext}", 'App\Http\Controllers\VoicemailController@start')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/post-call-action{ext}", 'App\Http\Controllers\CallFlowController@postCallAction')
     ->where('ext', $ext);
 Route::match(array('GET', 'POST'), "upgrade-advisor{ext}", 'App\Http\Controllers\UpgradeAdvisorController@index')
     ->where('ext', $ext);
 Route::match(array('GET', 'POST'), "/version", 'App\Http\Controllers\UpgradeAdvisorController@version');
-Route::match(array('GET', 'POST'), "/lng-selector{ext}", 'App\Http\Controllers\CallFlowController@languageSelector')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/province-voice-input{ext}", 'App\Http\Controllers\CallFlowController@provinceVoiceInput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-answer-response{ext}", 'App\Http\Controllers\CallFlowController@helplineAnswerResponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-outdial-response{ext}", 'App\Http\Controllers\CallFlowController@helplineOutdialResponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/sms-gateway{ext}", 'App\Http\Controllers\CallFlowController@smsGateway')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/meeting-search{ext}", 'App\Http\Controllers\CallFlowController@meetingSearch')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-search{ext}", 'App\Http\Controllers\HelplineController@search')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-dialer{ext}", 'App\Http\Controllers\HelplineController@dial')
-    ->where('ext', $ext);
 Route::get("/callWidget", 'App\Http\Controllers\CallWidgetController@index');
+
+// --- Twilio-facing inbound webhooks ---
+// Every route Twilio calls (IVR call flow, SMS gateway, voicemail, dialback,
+// helpline routing, status callbacks, TwiML readings) must carry a valid
+// X-Twilio-Signature. Applied as a single group so any future Twilio route
+// added here is covered by default.
+Route::middleware('twilio.signature')->group(function () use ($ext) {
+    Route::match(array('GET', 'POST'), "/fetch-jft{ext}", 'App\Http\Controllers\ReadingController@jft')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/fetch-spad{ext}", 'App\Http\Controllers\ReadingController@spad')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/", 'App\Http\Controllers\CallFlowController@index')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/info", 'App\Http\Controllers\CallFlowController@info')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/index{ext}", 'App\Http\Controllers\CallFlowController@index')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/input-method{ext}", 'App\Http\Controllers\CallFlowController@inputMethod')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/custom-ext{ext}", 'App\Http\Controllers\CallFlowController@customext')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/input-method-result{ext}", 'App\Http\Controllers\CallFlowController@inputMethodResult')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/zip-input{ext}", 'App\Http\Controllers\CallFlowController@zipinput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/city-or-county-voice-input{ext}", 'App\Http\Controllers\CallFlowController@cityorcountyinput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/service-body-ext-response{ext}", 'App\Http\Controllers\CallFlowController@servicebodyextresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/gender-routing-response{ext}", 'App\Http\Controllers\CallFlowController@genderroutingresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voice-input-result{ext}", 'App\Http\Controllers\CallFlowController@voiceinputresult')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/address-lookup{ext}", 'App\Http\Controllers\CallFlowController@addresslookup')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/playlist{ext}", 'App\Http\Controllers\CallFlowController@playlist')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/fallback{ext}", 'App\Http\Controllers\CallFlowController@fallback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/custom-ext-dialer{ext}", 'App\Http\Controllers\CallFlowController@customextdialer')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/dialback-dialer{ext}", 'App\Http\Controllers\CallFlowController@dialbackDialer')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/dialback{ext}", 'App\Http\Controllers\CallFlowController@dialback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/gender-routing{ext}", 'App\Http\Controllers\CallFlowController@genderrouting')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/province-lookup-list-response{ext}", 'App\Http\Controllers\CallFlowController@provincelookuplistresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/status{ext}", 'App\Http\Controllers\CallFlowController@statusCallback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voicemail-complete{ext}", 'App\Http\Controllers\VoicemailController@complete')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voicemail{ext}", 'App\Http\Controllers\VoicemailController@start')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/post-call-action{ext}", 'App\Http\Controllers\CallFlowController@postCallAction')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/lng-selector{ext}", 'App\Http\Controllers\CallFlowController@languageSelector')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/province-voice-input{ext}", 'App\Http\Controllers\CallFlowController@provinceVoiceInput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-answer-response{ext}", 'App\Http\Controllers\CallFlowController@helplineAnswerResponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-outdial-response{ext}", 'App\Http\Controllers\CallFlowController@helplineOutdialResponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/sms-gateway{ext}", 'App\Http\Controllers\CallFlowController@smsGateway')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/meeting-search{ext}", 'App\Http\Controllers\CallFlowController@meetingSearch')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-search{ext}", 'App\Http\Controllers\HelplineController@search')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-dialer{ext}", 'App\Http\Controllers\HelplineController@dial')
+        ->where('ext', $ext);
+});

--- a/src/tests/Feature/TwilioSignatureValidationTest.php
+++ b/src/tests/Feature/TwilioSignatureValidationTest.php
@@ -77,3 +77,33 @@ test('dev bypass skips validation for unsigned requests in non-production', func
 
     $response->assertStatus(200);
 })->with(['GET', 'POST']);
+
+// Regression coverage for the disclosed PoC (issue #1566): forged, unsigned
+// POSTs to the SMS gateway and the dialback dialer previously reached the
+// controller and drove call/SMS logic (persisting attacker-controlled rows).
+// With an auth token configured, the middleware must now reject these before
+// the controller runs. A 403 here means the controller never executed and
+// nothing was persisted.
+test('forged unsigned PoC POST to /sms-gateway is rejected', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    $response = $this->call('POST', '/sms-gateway.php', [
+        'SmsSid' => 'SMforgedATTACKER0001',
+        'From' => '+15005550001',
+        'To' => '+15005550002',
+        'Body' => 'FORGED-NO-SIGNATURE-PAYLOAD',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+test('forged unsigned PoC POST to /dialback-dialer is rejected', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    $response = $this->call('POST', '/dialback-dialer.php', [
+        'Digits' => '0000',
+        'Called' => '+15005550002',
+    ]);
+
+    $response->assertStatus(403);
+});

--- a/src/tests/Feature/TwilioSignatureValidationTest.php
+++ b/src/tests/Feature/TwilioSignatureValidationTest.php
@@ -49,6 +49,27 @@ test('allows a genuinely signed Twilio request', function ($method) {
     $response->assertStatus(200);
 })->with(['GET', 'POST']);
 
+test('allows a genuinely signed Twilio POST that carries body params', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    // A real Twilio webhook always POSTs body params (CallSid, From, ...). The
+    // middleware signs against $request->post() (POST body only) — never
+    // $request->all() — so a request bearing these params must still validate.
+    // This guards the exact regression where body-param handling breaks.
+    $params = [
+        'CallSid' => 'CA00000000000000000000000000000000',
+        'From' => '+15555550123',
+        'To' => '+15555550100',
+        'Digits' => '1',
+    ];
+
+    $signature = (new RequestValidator("testtoken"))->computeSignature('http://localhost', $params);
+
+    $response = $this->call('POST', '/', $params, [], [], ['HTTP_X_TWILIO_SIGNATURE' => $signature]);
+
+    $response->assertStatus(200);
+});
+
 test('dev bypass skips validation for unsigned requests in non-production', function ($method) {
     config(['twilio.disable_signature_validation' => true]);
 

--- a/src/tests/Feature/TwilioSignatureValidationTest.php
+++ b/src/tests/Feature/TwilioSignatureValidationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Twilio\Security\RequestValidator;
+
+beforeEach(function () {
+    @session_start();
+    $_SERVER['REQUEST_URI'] = "/";
+    $_REQUEST = null;
+    $_SESSION = null;
+
+    // Exercise the real middleware: turn the non-production dev bypass off so
+    // signature validation actually runs for the tests in this file.
+    config(['twilio.disable_signature_validation' => false]);
+});
+
+test('rejects a Twilio route with a missing signature', function ($method) {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('rejects a Twilio route with an invalid signature', function ($method) {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    $response = $this->call($method, '/', [], [], [], ['HTTP_X_TWILIO_SIGNATURE' => 'not-a-valid-signature']);
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('fails closed when no auth token is configured', function ($method) {
+    // No override_twilio_auth_token set -> SettingsService returns '' (empty),
+    // so the middleware must reject rather than skip validation.
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('allows a genuinely signed Twilio request', function ($method) {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    // The middleware validates against $request->fullUrl(); in the test harness
+    // (no forwarded headers) that is http://localhost for "/", with no params.
+    $signature = (new RequestValidator("testtoken"))->computeSignature('http://localhost', []);
+
+    $response = $this->call($method, '/', [], [], [], ['HTTP_X_TWILIO_SIGNATURE' => $signature]);
+
+    $response->assertStatus(200);
+})->with(['GET', 'POST']);
+
+test('dev bypass skips validation for unsigned requests in non-production', function ($method) {
+    config(['twilio.disable_signature_validation' => true]);
+
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(200);
+})->with(['GET', 'POST']);


### PR DESCRIPTION
Closes #1566

## Problem
On `4.5.x`, every Twilio-facing inbound webhook in `src/routes/web.php` (IVR call flow, SMS gateway, voicemail, dialback, helpline routing, status callbacks, TwiML readings) was processed **without** verifying the `X-Twilio-Signature` header. There was no `ValidateTwilioSignature` middleware and no `twilio.signature` alias. A request that did not originate from Twilio could drive the call/SMS logic (CWE-345 / CWE-347). Reported via coordinated disclosure by tonghuaroot.

## Changes
- **`ValidateTwilioSignature` middleware** — verifies `X-Twilio-Signature` with the Twilio SDK `RequestValidator` and the configured `twilio_auth_token`. **Fails closed**: rejects with 403 when the token is unconfigured or the signature is missing/invalid. The URL is derived from `$request->fullUrl()` (TrustProxies-resolved), **not** raw `X-Original-Host` / `X-Forwarded-*` headers.
- **`config/twilio.php`** — `disable_signature_validation` flag (`TWILIO_DISABLE_SIGNATURE_VALIDATION`), **off by default** and only honored in **non-production** (the middleware also gates on `app()->environment()`), so it can never weaken production.
- **`Kernel.php`** — registers the `twilio.signature` route-middleware alias.
- **`routes/web.php`** — applies the middleware via a **single route group** wrapping all 33 Twilio-facing routes, so future routes are covered by default. Non-Twilio routes (`/admin/*`, `/adminv2*`, `/bots/*`, `/msr/*`, `/v1/session/delete`, `/ping`, `/version`, `upgrade-advisor`, `/callWidget`) are left outside. Route paths and controller actions are otherwise unchanged (verified as an identical multiset vs the prior file).
- **`TrustProxies.php`** — `$proxies = '*'` for the AWS ELB deployment (the `X_FORWARDED_AWS_ELB` header was already enabled), so `fullUrl()` reflects the public host/scheme Twilio signed.
- **Tests** — `phpunit.xml` enables the dev bypass in the (non-production) test env so the existing suite stays green; new `TwilioSignatureValidationTest` covers missing signature → 403, invalid signature → 403, fail-closed with no token → 403, a genuinely-signed request → 200, and the dev bypass path.

## Acceptance criteria
- [x] Every Twilio-facing route rejects a missing/invalid signature (403).
- [x] Fails closed when `twilio_auth_token` is not configured; dev bypass is explicit, non-production, and off by default.
- [x] Signature URL comes from the TrustProxies-validated request (`fullUrl()`), not raw client headers; `TrustProxies` configured for the ELB.
- [x] A genuinely signed Twilio request works end-to-end (covered by test; run the suite in CI for full IVR/SMS/voicemail/dialback/helpline coverage).

## Notes on `main`
This intentionally does **not** reproduce `main`'s empty-token fail-open or its header-trusting `getSignatureUrl()`.

## Verification
`php -l` passes on all changed files; route paths/controller actions preserved (identical multiset vs HEAD). The full PHPUnit/Pest suite runs in CI — it could not be executed in the authoring environment (Composer-2 lock with no packagist access; local PHP 8.5 vs the project's 8.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNvKfde1HBABT763DSxBuJ