### PR TITLE
security: enforce Twilio webhook signature validation on all inbound routes (main/5.0.0)

### DIFF
--- a/src/app/Http/Middleware/ValidateTwilioSignature.php
+++ b/src/app/Http/Middleware/ValidateTwilioSignature.php
@@ -20,8 +20,10 @@ class ValidateTwilioSignature
     /**
      * Handle an incoming request.
      *
-     * Validates that the request is actually from Twilio by checking
-     * the X-Twilio-Signature header against the request body.
+     * Verifies that the request actually originated from Twilio by validating
+     * the X-Twilio-Signature header against the request URL and body. Fails
+     * closed: if no auth token is configured, or the signature is missing or
+     * invalid, the request is rejected with HTTP 403.
      *
      * @param Request $request
      * @param Closure $next
@@ -29,31 +31,39 @@ class ValidateTwilioSignature
      */
     public function handle(Request $request, Closure $next): mixed
     {
+        // Development-only bypass. Off by default, and only ever honored outside
+        // of production, so a misconfigured production deployment can never skip
+        // validation. Used by the test suite (see phpunit.xml).
+        $bypass = !app()->environment('production')
+            && config('twilio.disable_signature_validation', false);
+
+        if ($bypass) {
+            Log::warning('Twilio signature validation bypassed (non-production dev flag enabled)');
+            return $next($request);
+        }
+
         $authToken = $this->settings->get('twilio_auth_token');
 
-        // If no auth token configured, skip validation (for development)
+        // Fail closed: with no auth token we cannot verify the signature, so the
+        // request is rejected rather than allowed through.
         if (empty($authToken)) {
-            Log::warning('Twilio signature validation skipped: no auth token configured');
-            return $next($request);
+            Log::warning('Twilio signature validation failed: no auth token configured', [
+                'ip' => $request->ip(),
+            ]);
+            return response('Forbidden', 403);
         }
 
         $validator = new RequestValidator($authToken);
         $signature = $request->header('X-Twilio-Signature', '');
 
-        // Build the URL that Twilio used to sign the request
-        // When behind a proxy (ngrok, load balancer), we need to use the original URL
-        $url = $this->getSignatureUrl($request);
+        // Validate against the URL the framework resolved (honoring the trusted
+        // proxy configuration in TrustProxies), never raw client-supplied
+        // forwarding headers.
+        $url = $request->fullUrl();
 
-        // For POST requests, Twilio signs using POST body params only (not query params)
-        // $request->all() merges both, so we need to use post() for POST requests
+        // Twilio signs POST requests using the POST body params only; for GET the
+        // query string is already part of the URL.
         $params = $request->isMethod('POST') ? $request->post() : [];
-
-        Log::debug('Twilio signature validation attempt', [
-            'url' => $url,
-            'method' => $request->method(),
-            'params_count' => count($params),
-            'has_signature' => !empty($signature),
-        ]);
 
         if (!$validator->validate($signature, $url, $params)) {
             Log::warning('Invalid Twilio signature rejected', [
@@ -64,43 +74,5 @@ class ValidateTwilioSignature
         }
 
         return $next($request);
-    }
-
-    /**
-     * Get the URL that Twilio used to sign the request.
-     *
-     * When behind a reverse proxy (ngrok, load balancer, etc.), the URL
-     * Laravel sees may differ from what Twilio sent the request to.
-     * We reconstruct the original URL from forwarded headers.
-     *
-     * @param Request $request
-     * @return string
-     */
-    protected function getSignatureUrl(Request $request): string
-    {
-        // Check for X-Original-Host (set by some proxies) or X-Forwarded-Host
-        $host = $request->header('X-Original-Host')
-            ?? $request->header('X-Forwarded-Host')
-            ?? $request->getHost();
-
-        // Check for X-Forwarded-Proto for the scheme
-        $scheme = $request->header('X-Forwarded-Proto') ?? $request->getScheme();
-
-        // Use the raw REQUEST_URI to preserve exact encoding as Twilio sent it
-        // Laravel's getRequestUri() may re-encode the query string differently
-        $requestUri = $_SERVER['REQUEST_URI'] ?? $request->getRequestUri();
-
-        $url = $scheme . '://' . $host . $requestUri;
-
-        Log::debug('Twilio signature validation URL constructed', [
-            'constructed_url' => $url,
-            'scheme' => $scheme,
-            'host' => $host,
-            'request_uri' => $requestUri,
-            'x_forwarded_host' => $request->header('X-Forwarded-Host'),
-            'x_forwarded_proto' => $request->header('X-Forwarded-Proto'),
-        ]);
-
-        return $url;
     }
 }

--- a/src/config/twilio.php
+++ b/src/config/twilio.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Disable Twilio Signature Validation
+    |--------------------------------------------------------------------------
+    |
+    | Development/local ONLY escape hatch for the ValidateTwilioSignature
+    | middleware. It is off by default and is only honored outside of
+    | production (the middleware additionally gates on the environment), so
+    | enabling it can never weaken a production deployment.
+    |
+    */
+
+    'disable_signature_validation' => env('TWILIO_DISABLE_SIGNATURE_VALIDATION', false),
+
+];

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -25,6 +25,7 @@
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
     <server name="TELESCOPE_ENABLED" value="false"/>
+    <server name="TWILIO_DISABLE_SIGNATURE_VALIDATION" value="true"/>
   </php>
   <source>
     <include>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 
 $ext = '(\.php)?$';
 
+// --- Non-Twilio routes (admin portal, bots, MSR, health) ---
 Route::get("/admin{page}", 'App\Http\Controllers\AdminController@index')
     ->where('page', '.*')
     ->name("adminPortal");
@@ -11,81 +12,87 @@ Route::get("/bots/getMeetings", 'App\Http\Controllers\BotController@getMeetings'
 Route::get("/bots/getServiceBodyCoverage", 'App\Http\Controllers\BotController@getServiceBodyCoverage');
 Route::get("/msr/{latitude}/{longitude}", ['uses' => 'App\Http\Controllers\MeetingResultsController@index'])
     ->where(['latitude' => '.*', 'longitude' => '.*']);
-Route::match(array('GET', 'POST'), "/fetch-jft{ext}", 'App\Http\Controllers\ReadingController@jft')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/fetch-spad{ext}", 'App\Http\Controllers\ReadingController@spad')
-    ->where('ext', $ext);
 Route::match(array('GET', 'POST'), "/ping{ext}", 'App\Http\Controllers\PingController@index')
     ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/", 'App\Http\Controllers\CallFlowController@index')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/info", 'App\Http\Controllers\CallFlowController@info')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/index{ext}", 'App\Http\Controllers\CallFlowController@index')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/input-method{ext}", 'App\Http\Controllers\CallFlowController@inputMethod')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/custom-ext{ext}", 'App\Http\Controllers\CallFlowController@customext')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/input-method-result{ext}", 'App\Http\Controllers\CallFlowController@inputMethodResult')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/zip-input{ext}", 'App\Http\Controllers\CallFlowController@zipinput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/city-or-county-voice-input{ext}", 'App\Http\Controllers\CallFlowController@cityorcountyinput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/service-body-ext-response{ext}", 'App\Http\Controllers\CallFlowController@servicebodyextresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/gender-routing-response{ext}", 'App\Http\Controllers\CallFlowController@genderroutingresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voice-input-result{ext}", 'App\Http\Controllers\CallFlowController@voiceinputresult')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/address-lookup{ext}", 'App\Http\Controllers\CallFlowController@addresslookup')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/playlist{ext}", 'App\Http\Controllers\CallFlowController@playlist')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/fallback{ext}", 'App\Http\Controllers\CallFlowController@fallback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/custom-ext-dialer{ext}", 'App\Http\Controllers\CallFlowController@customextdialer')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/dialback-dialer{ext}", 'App\Http\Controllers\CallFlowController@dialbackDialer')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/dialback{ext}", 'App\Http\Controllers\CallFlowController@dialback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/gender-routing{ext}", 'App\Http\Controllers\CallFlowController@genderrouting')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/province-lookup-list-response{ext}", 'App\Http\Controllers\CallFlowController@provincelookuplistresponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/status{ext}", 'App\Http\Controllers\CallFlowController@statusCallback')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voicemail-complete{ext}", 'App\Http\Controllers\VoicemailController@complete')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/voicemail{ext}", 'App\Http\Controllers\VoicemailController@start')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/post-call-action{ext}", 'App\Http\Controllers\CallFlowController@postCallAction')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/lng-selector{ext}", 'App\Http\Controllers\CallFlowController@languageSelector')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/province-voice-input{ext}", 'App\Http\Controllers\CallFlowController@provinceVoiceInput')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-answer-response{ext}", 'App\Http\Controllers\CallFlowController@helplineAnswerResponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-outdial-response{ext}", 'App\Http\Controllers\CallFlowController@helplineOutdialResponse')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/sms-gateway{ext}", 'App\Http\Controllers\CallFlowController@smsGateway')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/meeting-search{ext}", 'App\Http\Controllers\CallFlowController@meetingSearch')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-search{ext}", 'App\Http\Controllers\HelplineController@search')
-    ->where('ext', $ext);
-Route::match(array('GET', 'POST'), "/helpline-dialer{ext}", 'App\Http\Controllers\HelplineController@dial')
-    ->where('ext', $ext);
-// WebRTC Call Handler - TwiML Application webhook endpoint
-// Protected by Twilio signature validation and rate limiting
-Route::match(array('GET', 'POST'), "/webrtc-call", 'App\Http\Controllers\WebRtcCallController@handleCall')
-    ->middleware(['twilio.signature', 'throttle:webrtc-call']);
-Route::match(array('GET', 'POST'), "/webrtc-status", 'App\Http\Controllers\WebRtcCallController@statusCallback')
-    ->middleware(['twilio.signature']);
 
-// WebChat SMS webhook - receives volunteer SMS replies
-Route::match(array('GET', 'POST'), "/webchat-sms", 'App\Http\Controllers\WebChatSmsController@handleSms')
-    ->middleware(['twilio.signature']);
+// --- Twilio-facing inbound webhooks ---
+// Every route Twilio calls (IVR call flow, SMS gateway, voicemail, dialback,
+// helpline routing, status callbacks, TwiML readings, and the WebRTC/WebChat
+// endpoints) must carry a valid X-Twilio-Signature. Applied as a single group
+// so any future Twilio route added here is covered by default.
+Route::middleware('twilio.signature')->group(function () use ($ext) {
+    Route::match(array('GET', 'POST'), "/fetch-jft{ext}", 'App\Http\Controllers\ReadingController@jft')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/fetch-spad{ext}", 'App\Http\Controllers\ReadingController@spad')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/", 'App\Http\Controllers\CallFlowController@index')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/info", 'App\Http\Controllers\CallFlowController@info')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/index{ext}", 'App\Http\Controllers\CallFlowController@index')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/input-method{ext}", 'App\Http\Controllers\CallFlowController@inputMethod')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/custom-ext{ext}", 'App\Http\Controllers\CallFlowController@customext')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/input-method-result{ext}", 'App\Http\Controllers\CallFlowController@inputMethodResult')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/zip-input{ext}", 'App\Http\Controllers\CallFlowController@zipinput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/city-or-county-voice-input{ext}", 'App\Http\Controllers\CallFlowController@cityorcountyinput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/service-body-ext-response{ext}", 'App\Http\Controllers\CallFlowController@servicebodyextresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/gender-routing-response{ext}", 'App\Http\Controllers\CallFlowController@genderroutingresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voice-input-result{ext}", 'App\Http\Controllers\CallFlowController@voiceinputresult')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/address-lookup{ext}", 'App\Http\Controllers\CallFlowController@addresslookup')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/playlist{ext}", 'App\Http\Controllers\CallFlowController@playlist')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/fallback{ext}", 'App\Http\Controllers\CallFlowController@fallback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/custom-ext-dialer{ext}", 'App\Http\Controllers\CallFlowController@customextdialer')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/dialback-dialer{ext}", 'App\Http\Controllers\CallFlowController@dialbackDialer')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/dialback{ext}", 'App\Http\Controllers\CallFlowController@dialback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/gender-routing{ext}", 'App\Http\Controllers\CallFlowController@genderrouting')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/province-lookup-list-response{ext}", 'App\Http\Controllers\CallFlowController@provincelookuplistresponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/status{ext}", 'App\Http\Controllers\CallFlowController@statusCallback')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voicemail-complete{ext}", 'App\Http\Controllers\VoicemailController@complete')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/voicemail{ext}", 'App\Http\Controllers\VoicemailController@start')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/post-call-action{ext}", 'App\Http\Controllers\CallFlowController@postCallAction')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/lng-selector{ext}", 'App\Http\Controllers\CallFlowController@languageSelector')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/province-voice-input{ext}", 'App\Http\Controllers\CallFlowController@provinceVoiceInput')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-answer-response{ext}", 'App\Http\Controllers\CallFlowController@helplineAnswerResponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-outdial-response{ext}", 'App\Http\Controllers\CallFlowController@helplineOutdialResponse')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/sms-gateway{ext}", 'App\Http\Controllers\CallFlowController@smsGateway')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/meeting-search{ext}", 'App\Http\Controllers\CallFlowController@meetingSearch')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-search{ext}", 'App\Http\Controllers\HelplineController@search')
+        ->where('ext', $ext);
+    Route::match(array('GET', 'POST'), "/helpline-dialer{ext}", 'App\Http\Controllers\HelplineController@dial')
+        ->where('ext', $ext);
+
+    // WebRTC Call Handler - TwiML Application webhook endpoint (also rate limited)
+    Route::match(array('GET', 'POST'), "/webrtc-call", 'App\Http\Controllers\WebRtcCallController@handleCall')
+        ->middleware('throttle:webrtc-call');
+    Route::match(array('GET', 'POST'), "/webrtc-status", 'App\Http\Controllers\WebRtcCallController@statusCallback');
+
+    // WebChat SMS webhook - receives volunteer SMS replies
+    Route::match(array('GET', 'POST'), "/webchat-sms", 'App\Http\Controllers\WebChatSmsController@handleSms');
+});

--- a/src/tests/Feature/TwilioSignatureValidationTest.php
+++ b/src/tests/Feature/TwilioSignatureValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Twilio\Security\RequestValidator;
+
+beforeEach(function () {
+    // Exercise the real middleware: turn the non-production dev bypass off (it is
+    // enabled globally via phpunit.xml) so signature validation actually runs for
+    // the tests in this file.
+    config(['twilio.disable_signature_validation' => false]);
+});
+
+test('rejects a Twilio route with a missing signature', function ($method) {
+    session()->put('override_twilio_auth_token', 'testtoken');
+
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('rejects a Twilio route with an invalid signature', function ($method) {
+    session()->put('override_twilio_auth_token', 'testtoken');
+
+    $response = $this->call($method, '/', [], [], [], ['HTTP_X_TWILIO_SIGNATURE' => 'not-a-valid-signature']);
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('fails closed when no auth token is configured', function ($method) {
+    // No override_twilio_auth_token set -> SettingsService returns '' (empty),
+    // so the middleware must reject rather than skip validation.
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(403);
+})->with(['GET', 'POST']);
+
+test('allows a genuinely signed Twilio request', function ($method) {
+    session()->put('override_twilio_auth_token', 'testtoken');
+
+    // The middleware validates against $request->fullUrl(); in the test harness
+    // (no forwarded headers) that is http://localhost for "/", with no params.
+    $signature = (new RequestValidator('testtoken'))->computeSignature('http://localhost', []);
+
+    $response = $this->call($method, '/', [], [], [], ['HTTP_X_TWILIO_SIGNATURE' => $signature]);
+
+    $response->assertStatus(200);
+})->with(['GET', 'POST']);
+
+test('dev bypass skips validation for unsigned requests in non-production', function ($method) {
+    config(['twilio.disable_signature_validation' => true]);
+
+    $response = $this->call($method, '/');
+
+    $response->assertStatus(200);
+})->with(['GET', 'POST']);


### PR DESCRIPTION
Closes #1570

Follow-up to #1566 (fixed for `4.5.x` in #1569); this hardens the same on `main` (the 5.0.0 line). Mirrors #1569, adapted to `main`'s route structure.

## Problem
`main` shipped a `ValidateTwilioSignature` middleware and a `twilio.signature` alias, but applied it to only **3** WebRTC/WebChat routes. The **entire legacy Twilio-facing route set** (IVR call flow, SMS gateway, voicemail, dialback, helpline routing, status callbacks, TwiML readings) was processed without verifying `X-Twilio-Signature` (CWE-345 / CWE-347). The existing middleware also **failed open** on an empty `twilio_auth_token` and reconstructed the signed URL from attacker-controllable `X-Original-Host` / `X-Forwarded-*` headers.

## Changes
- **`ValidateTwilioSignature`** — **fails closed** with 403 when the token is unconfigured or the signature is missing/invalid; derives the signed URL from the TrustProxies-resolved `$request->fullUrl()` instead of raw forwarding headers; `getSignatureUrl()` removed. Adds a dev bypass that is **off by default and only honored outside production**.
- **`config/twilio.php`** (new) — `disable_signature_validation` flag (`TWILIO_DISABLE_SIGNATURE_VALIDATION`), off by default, non-production only.
- **`routes/web.php`** — applies `twilio.signature` via a **single route group** wrapping every Twilio-facing route (36 routes) so future routes are covered by default; folds in the existing WebRTC/WebChat routes and **preserves `throttle:webrtc-call`**. `/admin*`, `/bots/*`, `/msr/*`, `/ping` stay outside.
- **`phpunit.xml`** — enables the dev bypass in the (non-production) test env so the existing suite stays green.
- **`TwilioSignatureValidationTest`** (new) — missing/invalid signature → 403, fail-closed with no token → 403, genuinely-signed request → 200, dev bypass → 200.

The `twilio.signature` Kernel alias and `TrustProxies` (`$proxies = '*'` with the AWS ELB header) were **already correct on `main`** and are unchanged.

## Acceptance criteria
- [x] Every Twilio-facing route (legacy IVR/SMS/voicemail/dialback/helpline/readings **and** WebRTC/WebChat) rejects a missing/invalid signature (403).
- [x] Validation **fails closed** when `twilio_auth_token` is not configured; the dev bypass is explicit, non-production, and off by default.
- [x] The signature URL is derived from `$request->fullUrl()` (TrustProxies-validated), not raw headers; `getSignatureUrl()` removed; `TrustProxies` configured for the ELB.
- [x] A genuinely signed request still works end-to-end (covered by test; full IVR/SMS/voicemail/dialback/helpline coverage via the CI suite).

## Verification
`php -l` passes on all changed files; route audit confirms all 36 Twilio routes carry `twilio.signature`, `/webrtc-call` retains `throttle:webrtc-call`, and admin/bots/msr/ping do not. The PHPUnit/Pest suite runs in CI — it could not run in the authoring environment (local PHP 8.5 vs the project's ≤8.4; packagist unreachable), same constraint noted in #1569.

Originating disclosure: #1566 (researcher tonghuaroot).