### PR TITLE
ci: run the full test suite and e2e on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,83 @@ jobs:
       - name: Lint
         uses: ./.github/actions/lint
 
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "8.2"
+          - "8.3"
+          - "8.4"
+          - "8.5"
+
+    services:
+      db-tests:
+        image: 'mysql/mysql-server:8.0'
+        env:
+          MYSQL_ROOT_PASSWORD: yap_root_password
+          MYSQL_DATABASE: yap_test
+          MYSQL_ROOT_HOST: '%'
+        ports:
+          - 3106:3306
+
+    steps:
+      - uses: actions/checkout@v6
+        id: code-checkout
+
+      - name: Setup PHP
+        uses: ./.github/actions/setup-php
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Lint
+        uses: ./.github/actions/lint
+
+      - name: Test
+        uses: ./.github/actions/test
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - "8.4"
+    services:
+      db-tests:
+        image: 'mysql/mysql-server:8.0'
+        env:
+          MYSQL_ROOT_PASSWORD: yap_root_password
+          MYSQL_DATABASE: yap_test
+          MYSQL_ROOT_HOST: '%'
+        ports:
+          - 3106:3306
+
+    steps:
+      - uses: actions/checkout@v6
+        id: code-checkout
+
+      - name: Setup PHP
+        uses: ./.github/actions/setup-php
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: E2E Tests
+        uses: ./.github/actions/e2e-test
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
   create_release:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php:
           - "8.2"
-    needs: [ lint ]
+    needs: [ lint, test, e2e ]
     name: Create release
     permissions:
       contents: write

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -4,8 +4,7 @@
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         stopOnFailure="true">
+         displayDetailsOnTestsThatTriggerWarnings="true">
   <testsuites>
     <testsuite name="Feature">
       <directory>./tests/Feature</directory>


### PR DESCRIPTION
Closes #1576

Part of the 5.0.0 release-verification effort (#1590) — Phase 1.

## Problem

`release.yml` gated `create_release` on `lint` alone. **A tag could publish a release zip that never ran a single test** — `5.0.0-beta1` and `5.0.0-beta2` were exactly that.

## Change

- Added `test` and `e2e` jobs to `release.yml`, mirroring `pull-request.yml`: PHP 8.2/8.3/8.4/8.5 matrix with `fail-fast: false`, a `db-tests` service on `mysql/mysql-server:8.0` publishing `3106:3306`, then `setup-php` → `install-deps` → `lint` → `test`. `e2e` is the same minus the matrix (8.4 only) using `.github/actions/e2e-test`.
- `create_release` now `needs: [lint, test, e2e]`.
- Dropped `stopOnFailure="true"` from `src/phpunit.xml` — during a release-verification run you want the full list of what broke, not just the first failure.

The PR-only `Auto-approve` step was deliberately omitted; it is meaningless on a tag push.

`package` already declares `needs: [lint, create_release]` and so inherits the new gate transitively — verified, no change needed there. Confirmed with `actionlint`, which reports only pre-existing shellcheck/`set-output` findings in the original `create_release` and `package` script blocks.

## Tradeoffs worth recording

**1. Releases now depend on third-party services being up.** The suite is not hermetic — `src/config.test.php` points `$bmlt_root_server` at `https://latest.aws.bmlt.app/main_server`, and `AddressLookupTest` asserts real Google Geocoder output (hence `GOOGLE_MAPS_API_KEY` is passed through, as in `pull-request.yml`). **A tag can now fail to publish because someone else's server is slow.** That is a genuine new failure mode on the most time-sensitive workflow in the repo, and an argument for prioritizing #1583 (make the suite hermetic) — but a release that cannot be verified is worse than one that occasionally needs a re-run.

**2. `tags: ['*']` means this fires for every tag, betas included.** The 4-version matrix plus Playwright adds several minutes to every tag push. Intended cost, but worth confirming nobody relies on tag pushes being fast.

**3. Possible small conflict with #1580**, which pins `zend.assertions=1` in the same `src/phpunit.xml`. Trivial to reconcile if both land close together.

## Verification status

The structural gate is verified: `create_release` declares all three jobs in `needs`, and GitHub Actions skips a dependent job when any `needs` entry fails.

**The failure-direction check from the acceptance criteria is not yet done.** Doing it properly means pushing a throwaway tag on a knowingly-broken commit and confirming `create_release` never runs — that fires the real `release` workflow against this repo and needs tag (and possibly release) cleanup afterward, so I did not do it unprompted. Happy to run it on request, or it can be done by whoever merges.

## Out of scope

`unstable.yml` (push to `main`) is still PHP 8.2 only with no e2e. Real gap, tracked as a follow-up on the epic — deliberately not expanded into here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)