### PR TITLE
security: close ungated WebChat SMS route, mark WebChat/WebRTC experimental for 5.0.0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,8 @@
 # Release Notes
 
 ### 5.0.0 (UNRELEASED)
+* **WebChat and WebRTC are EXPERIMENTAL in this release.** Both are disabled by default (`webchat_enabled` and `webrtc_enabled` default to `false`) and are unsupported in 5.0.0 — they ship without test coverage and their behavior may change or be removed in a future release. Do not enable them on a production helpline. While disabled, none of their routes are registered at all, so every WebChat/WebRTC endpoint returns 404. If you enable or disable either setting and you have run `php artisan route:cache`, run `php artisan route:clear` for the change to take effect. [#1577]
+* Fixed the WebChat volunteer SMS webhook (`/webchat-sms`) accepting and routing inbound messages even when WebChat was disabled. [#1577]
 * Volunteer shifts display are now sorted by day [#1338]
 * Custom Extensions are now included in call detail reports [#1433]
 * Dialbacks are now included in the call detail reports [#1409]

--- a/src/app/Http/Controllers/WebChatSmsController.php
+++ b/src/app/Http/Controllers/WebChatSmsController.php
@@ -3,17 +3,19 @@
 namespace App\Http\Controllers;
 
 use App\Services\ChatSessionService;
+use App\Services\SettingsService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use Twilio\TwiML\MessagingResponse;
 
 class WebChatSmsController extends Controller
 {
-    protected ChatSessionService $chatService;
+    protected SettingsService $settings;
 
-    public function __construct(ChatSessionService $chatService)
+    public function __construct(SettingsService $settings)
     {
-        $this->chatService = $chatService;
+        $this->settings = $settings;
     }
 
     /**
@@ -22,6 +24,15 @@ class WebChatSmsController extends Controller
      */
     public function handleSms(Request $request)
     {
+        // WebChat is experimental and disabled by default. When it is off this
+        // endpoint must not route anything: receiveVolunteerReply() matches an
+        // inbound SMS to a chat session by phone number, so an ungated call is a
+        // confidentiality risk, not just dead code.
+        if (!$this->isWebchatEnabled()) {
+            Log::debug("WebChat SMS received while webchat is disabled, ignoring");
+            return $this->emptyResponse();
+        }
+
         $from = $request->get('From');
         $to = $request->get('To');
         $body = $request->get('Body');
@@ -36,8 +47,12 @@ class WebChatSmsController extends Controller
             return $this->emptyResponse();
         }
 
+        // Resolved lazily so a disabled webchat never builds the chat session
+        // service graph (Twilio client, root server, meeting results).
+        $chatService = App::make(ChatSessionService::class);
+
         // Try to route this to a chat session
-        $result = $this->chatService->receiveVolunteerReply($from, $body, $to);
+        $result = $chatService->receiveVolunteerReply($from, $body, $to);
 
         if (!$result['success']) {
             // No active chat session - this might be a regular SMS, pass through
@@ -49,6 +64,18 @@ class WebChatSmsController extends Controller
 
         // Return empty TwiML response - we don't send an automatic reply
         return $this->emptyResponse();
+    }
+
+    /**
+     * Check if webchat is enabled
+     *
+     * Deliberately does not use SettingsService::has(): has() is
+     * !is_null(get()), and get() falls back to the allowlist default of false,
+     * so has() is always true for this setting and would mean nothing here.
+     */
+    protected function isWebchatEnabled(): bool
+    {
+        return (bool)$this->settings->get('webchat_enabled');
     }
 
     /**

--- a/src/app/Services/SettingsService.php
+++ b/src/app/Services/SettingsService.php
@@ -86,20 +86,20 @@ class SettingsService
         'voicemail_playback_grace_hours' => ['description' => '', 'default' => 48, 'overridable' => true, 'hidden' => false],
         'volunteer_auto_answer' => ['description' => '/helpline/volunteer-auto-answer', 'default'=>false, 'overridable' => true, 'hidden' => false],
         'word_language' => ['description' => '', 'default' => 'en-US', 'overridable' => true, 'hidden' => false],
-        'webrtc_enabled' => ['description' => '/webrtc/enabling-webrtc', 'default' => false, 'overridable' => false, 'hidden' => false],
-        'twilio_api_key' => ['description' => '/webrtc/twilio-api-key', 'default' => '', 'overridable' => false, 'hidden' => true],
-        'twilio_api_secret' => ['description' => '/webrtc/twilio-api-secret', 'default' => '', 'overridable' => false, 'hidden' => true],
-        'twilio_twiml_app_sid' => ['description' => '/webrtc/twiml-app-sid', 'default' => '', 'overridable' => false, 'hidden' => true],
-        'webrtc_allowed_origins' => ['description' => '/webrtc/cors-origins', 'default' => '*', 'overridable' => false, 'hidden' => false],
-        'webrtc_token_rate_limit' => ['description' => '/webrtc/rate-limiting', 'default' => 5, 'overridable' => false, 'hidden' => false],
-        'webrtc_call_rate_limit' => ['description' => '/webrtc/rate-limiting', 'default' => 3, 'overridable' => false, 'hidden' => false],
-        'webchat_enabled' => ['description' => '/webchat/enabling-webchat', 'default' => false, 'overridable' => false, 'hidden' => false],
-        'webchat_timeout_minutes' => ['description' => '/webchat/session-timeout', 'default' => 30, 'overridable' => false, 'hidden' => false],
-        'webchat_meeting_search_enabled' => ['description' => '/webchat/meeting-search', 'default' => true, 'overridable' => false, 'hidden' => false],
-        'webchat_no_coverage_message' => ['description' => '/webchat/custom-messages', 'default' => 'Sorry, there is no coverage for your location.', 'overridable' => true, 'hidden' => false],
-        'webchat_no_volunteers_message' => ['description' => '/webchat/custom-messages', 'default' => 'Sorry, no volunteers are available at this time. Please try again later.', 'overridable' => true, 'hidden' => false],
-        'webchat_volunteer_sms_prefix' => ['description' => '/webchat/custom-messages', 'default' => 'New web chat request', 'overridable' => true, 'hidden' => false],
-        'webchat_rate_limit' => ['description' => '/webchat/rate-limiting', 'default' => 10, 'overridable' => false, 'hidden' => false]
+        'webrtc_enabled' => ['description' => '', 'default' => false, 'overridable' => false, 'hidden' => false],
+        'twilio_api_key' => ['description' => '', 'default' => '', 'overridable' => false, 'hidden' => true],
+        'twilio_api_secret' => ['description' => '', 'default' => '', 'overridable' => false, 'hidden' => true],
+        'twilio_twiml_app_sid' => ['description' => '', 'default' => '', 'overridable' => false, 'hidden' => true],
+        'webrtc_allowed_origins' => ['description' => '', 'default' => '*', 'overridable' => false, 'hidden' => false],
+        'webrtc_token_rate_limit' => ['description' => '', 'default' => 5, 'overridable' => false, 'hidden' => false],
+        'webrtc_call_rate_limit' => ['description' => '', 'default' => 3, 'overridable' => false, 'hidden' => false],
+        'webchat_enabled' => ['description' => '', 'default' => false, 'overridable' => false, 'hidden' => false],
+        'webchat_timeout_minutes' => ['description' => '', 'default' => 30, 'overridable' => false, 'hidden' => false],
+        'webchat_meeting_search_enabled' => ['description' => '', 'default' => true, 'overridable' => false, 'hidden' => false],
+        'webchat_no_coverage_message' => ['description' => '', 'default' => 'Sorry, there is no coverage for your location.', 'overridable' => true, 'hidden' => false],
+        'webchat_no_volunteers_message' => ['description' => '', 'default' => 'Sorry, no volunteers are available at this time. Please try again later.', 'overridable' => true, 'hidden' => false],
+        'webchat_volunteer_sms_prefix' => ['description' => '', 'default' => 'New web chat request', 'overridable' => true, 'hidden' => false],
+        'webchat_rate_limit' => ['description' => '', 'default' => 10, 'overridable' => false, 'hidden' => false]
     ];
 
     public static array $dateCalculationsMap =
@@ -192,6 +192,29 @@ class SettingsService
     public function has($name): bool
     {
         return !is_null($this->get($name));
+    }
+
+    /**
+     * Read a boolean feature flag during route registration.
+     *
+     * Route files are loaded from RouteServiceProvider::boot(), earlier in the
+     * lifecycle than a controller runs: no session has been started and the
+     * request is not fully resolved. Only settings with 'overridable' => false
+     * are safe here, since get() consults request()/session() for overridable
+     * ones. Anything unexpected fails closed - these flags guard experimental
+     * features that ship off, so "off" is the safe answer.
+     *
+     * Note this reads the flag at boot, which means `php artisan route:cache`
+     * freezes whichever value was current when the cache was built. Run
+     * `php artisan route:clear` after toggling one of these settings.
+     */
+    public static function featureEnabledAtBoot(string $name): bool
+    {
+        try {
+            return (bool)app(self::class)->get($name);
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 
     public function geocodingApiUri(): string

--- a/src/resources/views/errors/404.blade.php
+++ b/src/resources/views/errors/404.blade.php
@@ -1,2 +1,2 @@
 <h1>404</h1>
-{{ $_SERVER['REQUEST_URI'] }}
+{{ $_SERVER['REQUEST_URI'] ?? '' }}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Admin\VoicemailController;
 use App\Http\Controllers\Api\V1\WebRtcController;
 use App\Http\Controllers\Api\V1\WebChatController;
 use App\Http\Controllers\UpgradeAdvisorController;
+use App\Services\SettingsService;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\Admin\SettingsController;
 
@@ -25,40 +26,47 @@ Route::group([
     Route::get('/openapi.json', [SwaggerController::class, 'openapi'])->name('openapi');
 
     // WebRTC Widget endpoints (public, rate-limited)
+    // EXPERIMENTAL, default off: registered only when webrtc_enabled is true, so
+    // a disabled feature is a 404 rather than a reachable endpoint that refuses.
     // Token endpoint uses configurable rate limit (default: 5/min)
-    Route::group(['prefix' => 'webrtc'], function () {
-        Route::get('token', [WebRtcController::class, 'token'])
-            ->middleware('throttle:webrtc-token')
-            ->name('webrtc.token');
-        Route::get('config', [WebRtcController::class, 'config'])
-            ->middleware('throttle:60,1')
-            ->name('webrtc.config');
-    });
+    if (SettingsService::featureEnabledAtBoot('webrtc_enabled')) {
+        Route::group(['prefix' => 'webrtc'], function () {
+            Route::get('token', [WebRtcController::class, 'token'])
+                ->middleware('throttle:webrtc-token')
+                ->name('webrtc.token');
+            Route::get('config', [WebRtcController::class, 'config'])
+                ->middleware('throttle:60,1')
+                ->name('webrtc.config');
+        });
+    }
 
     // WebChat Widget endpoints (public, rate-limited)
-    Route::group(['prefix' => 'webchat'], function () {
-        Route::get('config', [WebChatController::class, 'config'])
-            ->middleware('throttle:60,1')
-            ->name('webchat.config');
-        Route::get('meetings', [WebChatController::class, 'searchMeetings'])
-            ->middleware('throttle:30,1')
-            ->name('webchat.meetings');
-        Route::get('session', [WebChatController::class, 'getSession'])
-            ->middleware('throttle:60,1')
-            ->name('webchat.session.get');
-        Route::post('session', [WebChatController::class, 'createSession'])
-            ->middleware('throttle:webchat')
-            ->name('webchat.session.create');
-        Route::post('session/{sessionId}/message', [WebChatController::class, 'sendMessage'])
-            ->middleware('throttle:webchat')
-            ->name('webchat.message.send');
-        Route::get('session/{sessionId}/messages', [WebChatController::class, 'getMessages'])
-            ->middleware('throttle:120,1')
-            ->name('webchat.messages.get');
-        Route::post('session/{sessionId}/close', [WebChatController::class, 'closeSession'])
-            ->middleware('throttle:60,1')
-            ->name('webchat.session.close');
-    });
+    // EXPERIMENTAL, default off: see the note on the webrtc group above.
+    if (SettingsService::featureEnabledAtBoot('webchat_enabled')) {
+        Route::group(['prefix' => 'webchat'], function () {
+            Route::get('config', [WebChatController::class, 'config'])
+                ->middleware('throttle:60,1')
+                ->name('webchat.config');
+            Route::get('meetings', [WebChatController::class, 'searchMeetings'])
+                ->middleware('throttle:30,1')
+                ->name('webchat.meetings');
+            Route::get('session', [WebChatController::class, 'getSession'])
+                ->middleware('throttle:60,1')
+                ->name('webchat.session.get');
+            Route::post('session', [WebChatController::class, 'createSession'])
+                ->middleware('throttle:webchat')
+                ->name('webchat.session.create');
+            Route::post('session/{sessionId}/message', [WebChatController::class, 'sendMessage'])
+                ->middleware('throttle:webchat')
+                ->name('webchat.message.send');
+            Route::get('session/{sessionId}/messages', [WebChatController::class, 'getMessages'])
+                ->middleware('throttle:120,1')
+                ->name('webchat.messages.get');
+            Route::post('session/{sessionId}/close', [WebChatController::class, 'closeSession'])
+                ->middleware('throttle:60,1')
+                ->name('webchat.session.close');
+        });
+    }
 
     Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::resource('user', 'AuthController')->only(['index']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\SettingsService;
 use Illuminate\Support\Facades\Route;
 
 $ext = '(\.php)?$';
@@ -89,10 +90,18 @@ Route::middleware('twilio.signature')->group(function () use ($ext) {
         ->where('ext', $ext);
 
     // WebRTC Call Handler - TwiML Application webhook endpoint (also rate limited)
-    Route::match(array('GET', 'POST'), "/webrtc-call", 'App\Http\Controllers\WebRtcCallController@handleCall')
-        ->middleware('throttle:webrtc-call');
-    Route::match(array('GET', 'POST'), "/webrtc-status", 'App\Http\Controllers\WebRtcCallController@statusCallback');
+    // EXPERIMENTAL, default off: registered only when webrtc_enabled is true.
+    if (SettingsService::featureEnabledAtBoot('webrtc_enabled')) {
+        Route::match(array('GET', 'POST'), "/webrtc-call", 'App\Http\Controllers\WebRtcCallController@handleCall')
+            ->middleware('throttle:webrtc-call');
+        Route::match(array('GET', 'POST'), "/webrtc-status", 'App\Http\Controllers\WebRtcCallController@statusCallback');
+    }
 
     // WebChat SMS webhook - receives volunteer SMS replies
-    Route::match(array('GET', 'POST'), "/webchat-sms", 'App\Http\Controllers\WebChatSmsController@handleSms');
+    // EXPERIMENTAL, default off: registered only when webchat_enabled is true.
+    // handleSms() also gates on the flag, so this stays closed even if the route
+    // table was cached while the feature was on.
+    if (SettingsService::featureEnabledAtBoot('webchat_enabled')) {
+        Route::match(array('GET', 'POST'), "/webchat-sms", 'App\Http\Controllers\WebChatSmsController@handleSms');
+    }
 });

--- a/src/tests/Feature/OpenApiRouteValidationTest.php
+++ b/src/tests/Feature/OpenApiRouteValidationTest.php
@@ -33,7 +33,7 @@ test('openapi annotations match actual routes', function () {
             }
         }
 
-        if (!$found) {
+        if (!$found && !isConditionallyRegistered($docRoute['path'])) {
             $nonExistent[] = sprintf(
                 "%s %s (documented in %s but route doesn't exist)",
                 $docRoute['method'],
@@ -237,4 +237,23 @@ function shouldBeDocumented(array $route): bool
 
     // All other API routes should be documented
     return true;
+}
+
+/**
+ * Determine if a documented route is only registered when a feature flag is on.
+ *
+ * WebChat and WebRTC are experimental and ship disabled in 5.0.0, so their
+ * routes are registered conditionally (see routes/api.php). Their @OA
+ * annotations are kept for operators who enable the features, but the routes
+ * are legitimately absent from the default route table, so "documented but
+ * doesn't exist" is expected here rather than documentation drift.
+ *
+ * This exemption is one-directional: when the flags are on the routes do get
+ * registered, and the undocumented check above still requires them to carry
+ * annotations. Remove this when the features are promoted in 5.1.0.
+ */
+function isConditionallyRegistered(string $path): bool
+{
+    return str_starts_with(strtolower($path), '/api/v1/webchat/')
+        || str_starts_with(strtolower($path), '/api/v1/webrtc/');
 }

--- a/src/tests/Feature/VoicemailCompleteTest.php
+++ b/src/tests/Feature/VoicemailCompleteTest.php
@@ -14,11 +14,28 @@ use App\Services\RootServerService;
 use App\Structures\ServiceBodyCallHandling;
 use App\Structures\VolunteerData;
 use App\Structures\VolunteerRoutingParameters;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\Assert;
 use PHPMailer\PHPMailer\PHPMailer;
 use Tests\RootServerMocks;
 
 beforeEach(function () {
+    // VoicemailService::sendEmailForVoicemail() fetches the recording over the
+    // network (Http::get) while assembling the notification email, so this file
+    // depended on demo.bmlt.app being reachable from whatever host runs the
+    // suite. When that connect times out, the service's catch swallows a
+    // GuzzleHttp ConnectException and returns before setting Body/AltBody,
+    // failing every body and attachment assertion here - 48 of them, seen on a
+    // CI runner that could not reach the host on port 80.
+    //
+    // Stub only that host so the assertions exercise the mail assembly rather
+    // than the network. Nothing here asserts the downloaded bytes; the
+    // attachment assertions cover path, name, encoding, MIME type and
+    // disposition, all of which PHPMailer derives from the URL.
+    Http::fake([
+        'demo.bmlt.app/*' => Http::response('fake-recording-bytes', 200),
+    ]);
+
     $this->rootServerMocks = new RootServerMocks();
     $this->serviceBodyId = "1053";
     $this->parentServiceBodyId = "1052";

--- a/src/tests/Feature/WebChatWebRtcDisabledTest.php
+++ b/src/tests/Feature/WebChatWebRtcDisabledTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * WebChat and WebRTC ship in 5.0.0 as EXPERIMENTAL and disabled by default.
+ *
+ * "Disabled" has to mean unreachable, not reachable-but-refusing, so these
+ * tests pin the shipping posture: with webchat_enabled and webrtc_enabled
+ * false (the defaults, and what config.test.php leaves unset), none of the
+ * routes are registered and the SMS webhook does no chat-session routing.
+ *
+ * These are gate tests only. They deliberately do not exercise WebChat/WebRTC
+ * internals, which remain untested until the features are promoted in 5.1.0.
+ */
+
+use App\Http\Controllers\WebChatSmsController;
+use App\Services\ChatSessionService;
+use App\Services\SettingsService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+/** Every route that must disappear when the feature flags are off. */
+function experimentalWidgetRouteUris(): array
+{
+    return [
+        // routes/web.php - Twilio-facing webhooks
+        'webrtc-call',
+        'webrtc-status',
+        'webchat-sms',
+        // routes/api.php - public widget endpoints
+        'api/v1/webrtc/token',
+        'api/v1/webrtc/config',
+        'api/v1/webchat/config',
+        'api/v1/webchat/meetings',
+        'api/v1/webchat/session',
+        'api/v1/webchat/session/{sessionId}/message',
+        'api/v1/webchat/session/{sessionId}/messages',
+        'api/v1/webchat/session/{sessionId}/close',
+    ];
+}
+
+test('webchat and webrtc are disabled by default', function () {
+    $settings = new SettingsService();
+
+    expect($settings->get('webchat_enabled'))->toBeFalsy();
+    expect($settings->get('webrtc_enabled'))->toBeFalsy();
+});
+
+test('no webchat or webrtc route is registered while the features are disabled', function () {
+    $registered = collect(Route::getRoutes()->getRoutes())
+        ->map(fn($route) => $route->uri())
+        ->all();
+
+    foreach (experimentalWidgetRouteUris() as $uri) {
+        expect($registered)->not->toContain($uri);
+    }
+});
+
+test('the route table has no webchat or webrtc routes at all while disabled', function () {
+    $matching = collect(Route::getRoutes()->getRoutes())
+        ->map(fn($route) => $route->uri())
+        ->filter(fn($uri) => str_contains($uri, 'webchat') || str_contains($uri, 'webrtc'))
+        ->values()
+        ->all();
+
+    expect($matching)->toBeEmpty();
+});
+
+test('disabled webchat and webrtc endpoints return 404', function ($uri) {
+    expect($this->call('GET', $uri)->status())->toBe(404);
+    expect($this->call('POST', $uri)->status())->toBe(404);
+})->with([
+    '/webrtc-call',
+    '/webrtc-status',
+    '/webchat-sms',
+    '/api/v1/webrtc/token',
+    '/api/v1/webrtc/config',
+    '/api/v1/webchat/config',
+    '/api/v1/webchat/meetings',
+    '/api/v1/webchat/session',
+]);
+
+test('handleSms returns empty TwiML and never touches ChatSessionService when webchat is disabled', function () {
+    // Fail loudly if the controller resolves the chat service at all: routing an
+    // inbound SMS to a session by phone number is exactly what must not happen.
+    app()->bind(ChatSessionService::class, function () {
+        throw new RuntimeException('ChatSessionService must not be resolved while webchat is disabled');
+    });
+
+    $controller = new WebChatSmsController(new SettingsService());
+
+    $response = $controller->handleSms(Request::create('/webchat-sms', 'POST', [
+        'From' => '+15551234567',
+        'To' => '+15559876543',
+        'Body' => 'a volunteer reply that must not be routed',
+    ]));
+
+    expect($response->headers->get('Content-Type'))->toContain('text/xml');
+    expect($response->getContent())->toContain('<Response');
+    // Empty TwiML: no <Message> verb, nothing delivered anywhere.
+    expect($response->getContent())->not->toContain('<Message');
+});
+
+test('featureEnabledAtBoot reports the flags as off and fails closed on an unknown setting', function () {
+    expect(SettingsService::featureEnabledAtBoot('webchat_enabled'))->toBeFalse();
+    expect(SettingsService::featureEnabledAtBoot('webrtc_enabled'))->toBeFalse();
+    expect(SettingsService::featureEnabledAtBoot('a_setting_that_does_not_exist'))->toBeFalse();
+});
+
+test('webchat and webrtc settings do not advertise documentation pages that do not exist', function () {
+    $allowlist = (new SettingsService())->allowlist();
+
+    $widgetSettings = collect($allowlist)
+        ->filter(fn($_, $name) => str_starts_with($name, 'webchat_')
+            || str_starts_with($name, 'webrtc_')
+            || str_starts_with($name, 'twilio_api_')
+            || $name === 'twilio_twiml_app_sid');
+
+    expect($widgetSettings)->not->toBeEmpty();
+
+    foreach ($widgetSettings as $name => $definition) {
+        expect($definition['description'] ?? '')
+            ->toBe('', "Setting '{$name}' links to documentation that has not been written yet");
+    }
+});


### PR DESCRIPTION
Closes #1577

Phase 1 of the 5.0.0 release-verification effort (#1590). WebChat and WebRTC ship in 5.0.0 **disabled and experimental**. Both flags already defaulted to `false` — this makes "disabled" actually mean unreachable.

## 1. The ungated SMS route (the actual security fix)

`WebChatSmsController::handleSms()` had **no gate at all**, unlike every other entry point. It called `receiveVolunteerReply()` unconditionally, which routes an inbound volunteer SMS into a chat session **by phone number**. On an untested code path that's a confidentiality incident on an NA helpline, not a bug report.

It now returns empty TwiML before touching the chat service. `ChatSessionService` is resolved lazily (`App::make`) rather than constructor-injected, so a disabled webchat never builds that service graph at all — satisfying "without touching ChatSessionService" literally.

Per the implementation note, the new gate uses `get()` directly, **not** `has()`. `has()` is `!is_null(get())` and `get()` falls back to the allowlist default of `false`, so `has()` is always true here and would mean nothing. Comment added so nobody re-derives that trap. (The existing `isWebchatEnabled()` helpers on the other controllers were left alone — scope discipline; flagged for #1587.)

## 2. Conditional route registration — chose it, and here's the evidence

I went with conditional registration rather than the 404 fallback. Verified empirically in **both** directions with `artisan route:list`: all 11 routes present with the flags on, **zero** routes matching `webchat|webrtc` with them off. No boot-time exception.

The note flagged two risks. Both check out as manageable:

**Settings resolution at boot.** `SettingsService::get()` only consults `request()`/`session()` for settings with `overridable => true`. Both flags are `overridable => false`, so the risky branch is never reached. Reads go through a new `SettingsService::featureEnabledAtBoot()` that documents this constraint and **fails closed** on any `Throwable` — for a default-off experimental feature, "off" is the safe answer.

**`route:cache` bakes in the flag.** Real, and I did not make it go away:
- Documented on the helper and in the release notes ("run `php artisan route:clear` after toggling").
- `handleSms()` keeps its **own** gate, so a stale cached route table still cannot route an SMS. Defense in depth, not either/or.
- Mitigating context: nothing in the repo runs `route:cache`, and these settings live in `config.php` with no runtime write path — toggling already requires a file edit, so an operator is already in deploy-step territory.

Rate limiters in `RouteServiceProvider` are defined unconditionally, so unregistering routes doesn't orphan a reference — confirmed, boots clean. No `route()` name-helper usages anywhere, so nothing breaks on the absent names.

Note the ticket says "five routes"; it's really **3 in `web.php` + 8 in `api.php`**. The test asserts all 11.

## 3. Settings no longer advertise unwritten docs

**14** settings (not just the 2 in the ticket) pointed into `/webrtc/` and `/webchat/`, neither of which exists. All cleared — `SettingsController` already renders an empty description as no link. Verified only those 14 changed.

## 4. Release notes

5.0.0 section states plainly that both are experimental, default-off, unsupported, untested, and not for production helplines — plus the `route:clear` caveat.

## OpenAPI test — one honest side effect

Conditional registration broke `OpenApiRouteValidationTest`, which compares `@OA` annotations against the live route table (9 documented routes stopped existing). **This failure was mine, and it's fixed.**

Documented routes under the two conditional prefixes are now exempt from the *"documented but doesn't exist"* check **only**. The reverse check is untouched: when the flags are on, those routes still must carry annotations. I kept the annotations rather than deleting them — they're accurate for operators who enable the feature, and stripping them would mean an invasive edit to controllers this PR shouldn't touch.

## Testing

New `WebChatWebRtcDisabledTest` — **14 tests, 51 assertions**, gates only:
- flags default off; no `webchat`/`webrtc` route registered at all; all 11 URIs absent
- the endpoints 404
- `handleSms()` returns empty TwiML and **never resolves `ChatSessionService`** (a container binding throws if it's touched)
- `featureEnabledAtBoot()` reports off and fails closed on an unknown setting
- no webchat/webrtc setting advertises a doc page

Deliberately **no** tests of WebChat/WebRTC internals and **no** refactor of `ChatSessionService` — those stay untested until promotion.

## Test suite status

`make lint` passes clean (exit 0). CI is green on all of 8.2 / 8.3 / 8.4 / 8.5 and e2e.

Locally `make test` reports **20 failures**, and I want to be precise about them: **all 20 are pre-existing and unrelated.** I established this by stashing the entire changeset and re-running — the clean tree produces the same 20, in the same 4 files (`AddressLookupTest` 6, `HelplineSearchTest` 8, `UpgradeAdvisorTest` 4, `SmsGatewayTest` 2). They're geocoding-dependent (`AddressLookupTest` expects `searching meeting information for Raleigh, NC, USA` and gets a retry redirect — no Google Maps API key locally). They pass in CI, which has the `GOOGLE_MAPS_API_KEY` secret.

## Two follow-up commits after the first CI run

Both are unrelated to the WebChat/WebRTC work but were blocking this branch. Recording them here so reviewers aren't surprised by files outside the ticket's scope.

**`f95f1be5` — 404 view fataled when `REQUEST_URI` was unset.** My eight new "disabled endpoints return 404" cases failed in CI with 500. Root cause was not the gating: `errors/404.blade.php` dereferences `$_SERVER['REQUEST_URI']` directly, and PHPUnit never populates that key, so rendering the 404 page threw a `ViewException` that Laravel converted to a 500. Pre-existing — confirmed by probing an arbitrary unrouted path, which also returned 500 — but nothing had ever exercised an unrouted path under test before. It only reproduces with a `.env` present, which is why CI saw it (the test action does `mv .env.pipeline .env`) and a local run without one did not. Fixed with a null-coalesce, a no-op in any real web SAPI where `REQUEST_URI` is always set.

I should be straight that this **was a new failure I introduced**, contrary to my initial "0 new failures" claim — that claim came from a local run whose environment never exercised the 404 path.

**`1c8c2f33` — voicemail test required a live fetch of `demo.bmlt.app`.** `test (8.5)` then failed with 48 `VoicemailCompleteTest` failures while 8.2/8.3/8.4 passed on the identical commit. `VoicemailService::sendEmailForVoicemail()` calls `Http::get()` on the recording URL while assembling the email; when that connect times out, the `catch` swallows the exception and returns before setting `Body`/`AltBody`, failing every body and attachment assertion.

The `laravel.log` artifact uploaded by the failing job recorded the cause 48 times:

```
GuzzleHttp\Exception\ConnectException: cURL error 28: Failed to connect to
demo.bmlt.app port 80 after 10002 ms: Timeout was reached
```

That accounts for the whole signature: the identical 48/502 split across two runs (deterministic once a runner cannot reach the host), the uniform ~11s per test (the 10s connect timeout), and the same job passing earlier on a runner that could reach it. Not PHP-8.5-specific, and it could strand any PR in this repo.

Fixed by faking only that host in the file's `beforeEach`. The assertions are unchanged — still 56 tests / 1148 assertions — and no assertion covers the downloaded bytes; the attachment checks cover path, name, encoding, MIME type and disposition, all derived by PHPMailer from the URL. I verified the stub genuinely intercepts rather than merely coexisting with a currently-reachable host (a probe confirmed the faked body is returned, never the live 301). The 8.5 job now runs in 12m41s versus 21m/42m, consistent with the timeouts being gone.

**This fixes the test, not the underlying bug.** The production `catch` still swallows a failed recording fetch and calls `send()` anyway, so a voicemail notification can go out with no attachment and an unset body — a silent failure on a helpline notification path. That's a production behavior change well outside #1577, so I left it alone; it deserves its own issue and may belong in the #1590 verification effort.

## Follow-up

A 5.1.0 tracking issue for promoting both features with real test coverage still needs to be opened — the last acceptance-criteria box. Flagging rather than silently claiming it: happy to open it, just say the word (or it may belong under #1590's umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
