### PR TITLE
test: simulated Twilio account + CallScenario driver

### DIFF
--- a/src/tests/CallScenario.php
+++ b/src/tests/CallScenario.php
@@ -3,8 +3,10 @@
 namespace Tests;
 
 use App\Constants\TwilioCallStatus;
+use App\Models\RecordEvent;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\Assert;
 use Tests\Fakes\FakeTwilioAccount;
 use Tests\Support\TwimlExpectations;
 
@@ -237,5 +239,23 @@ class CallScenario extends TwilioCallTestBuilder
         }
 
         return [$path, $query];
+    }
+
+    public function assertHasEvent(int $eventId): self
+    {
+        $callSids = [$this->callSid];
+        foreach ($this->twilio->pendingLegs as $leg) {
+            $callSids[] = $leg['sid'];
+        }
+
+        $event = RecordEvent::whereIn('callsid', array_unique($callSids))
+            ->where('event_id', $eventId)
+            ->first();
+        Assert::assertNotNull(
+            $event,
+            "Expected to find event with ID {$eventId} for scenario calls " . implode(', ', $callSids),
+        );
+
+        return $this;
     }
 }

--- a/src/tests/CallScenario.php
+++ b/src/tests/CallScenario.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Tests;
+
+use App\Constants\TwilioCallStatus;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Tests\Fakes\FakeTwilioAccount;
+use Tests\Support\TwimlExpectations;
+
+class CallScenario extends TwilioCallTestBuilder
+{
+    public FakeTwilioAccount $twilio;
+
+    private ?string $conferenceName = null;
+
+    private ?string $conferenceStatusCallback = null;
+
+    public function __construct(array $settings = [])
+    {
+        $this->callSid = 'CA' . Str::uuid()->toString();
+        $this->phoneNumberSid = 'PN' . Str::uuid()->toString();
+        [$this->utility, $this->twilio] = setupFakeTwilioService();
+        foreach ($settings as $key => $value) {
+            $this->utility->settings->set($key, $value);
+        }
+    }
+
+    public function startCall(string $fromNumber, string $toNumber, string $method = 'GET'): self
+    {
+        $this->callData = [
+            'CallSid' => $this->callSid,
+            'Called' => $toNumber,
+            'From' => $fromNumber,
+            'To' => $toNumber,
+        ];
+
+        $this->twilio->registerInboundCall($this->callSid, $fromNumber, $toNumber, $this->phoneNumberSid);
+        $this->twilio->registerIncomingPhoneNumber($this->phoneNumberSid, $toNumber);
+
+        $this->lastResponse = test()->call($method, '/index.php', $this->callData);
+        $this->lastResponse->assertStatus(200);
+
+        return $this;
+    }
+
+    public function lastTwiml(): string
+    {
+        return $this->lastResponse->getContent();
+    }
+
+    public function joinConference(): self
+    {
+        $twiml = $this->lastResponse->getContent();
+        $conferenceName = TwimlExpectations::assertDialsConference($twiml);
+        $statusCallback = TwimlExpectations::getAttributeFromTag($twiml, 'Conference', 'statusCallback');
+
+        $this->conferenceName = $conferenceName;
+        $this->conferenceStatusCallback = html_entity_decode($statusCallback, ENT_QUOTES);
+
+        $this->twilio->createConference($conferenceName);
+        $this->twilio->addConferenceParticipant($conferenceName, $this->callSid);
+        $this->twilio->resetConferenceReadCount();
+
+        $this->lastResponse = $this->dispatchWebhook(
+            $statusCallback,
+            [
+                'StatusCallbackEvent' => 'participant-join',
+                'SequenceNumber' => '1',
+                'FriendlyName' => $conferenceName,
+                'CallSid' => $this->callSid,
+                'SearchType' => '1',
+            ],
+        );
+        $this->lastResponse->assertStatus(200);
+
+        return $this;
+    }
+
+    public function answerVolunteer(int $n, string $digits = '1'): self
+    {
+        $leg = $this->pendingLeg($n);
+        $this->lastResponse = $this->dispatchWebhook(
+            $leg['url'],
+            [
+                'CallSid' => $leg['sid'],
+                'Called' => $leg['to'],
+            ],
+        );
+        $this->lastResponse->assertStatus(200);
+
+        $twiml = $this->lastResponse->getContent();
+        if (str_contains($twiml, '<Redirect')) {
+            $xml = simplexml_load_string($twiml);
+            $redirectElements = $xml->xpath('//Redirect');
+            $redirect = (string) $redirectElements[0];
+            $this->lastResponse = $this->dispatchWebhook(
+                $redirect,
+                [
+                    'CallSid' => $leg['sid'],
+                    'Called' => $leg['to'],
+                    'Digits' => $digits,
+                ],
+            );
+            $this->lastResponse->assertStatus(200);
+            $twiml = $this->lastResponse->getContent();
+        } elseif (str_contains($twiml, '<Gather')) {
+            $action = TwimlExpectations::getAttributeFromTag($twiml, 'Gather', 'action');
+            $this->lastResponse = $this->dispatchWebhook(
+                $action,
+                [
+                    'CallSid' => $leg['sid'],
+                    'Called' => $leg['to'],
+                    'Digits' => $digits,
+                ],
+            );
+            $this->lastResponse->assertStatus(200);
+            $twiml = $this->lastResponse->getContent();
+        }
+
+        if (str_contains($twiml, '<Conference')) {
+            $conferenceName = trim((string) simplexml_load_string($twiml)->xpath('//Conference')[0]);
+            $this->twilio->addConferenceParticipant($conferenceName, $leg['sid']);
+        }
+
+        return $this;
+    }
+
+    public function volunteerRejects(int $n): self
+    {
+        return $this->answerVolunteer($n, '2');
+    }
+
+    public function volunteerNoAnswer(int $n, string $status = TwilioCallStatus::NOANSWER): self
+    {
+        $leg = $this->pendingLeg($n);
+        $this->lastResponse = $this->dispatchWebhook(
+            $leg['statusCallback'],
+            [
+                'CallSid' => $leg['sid'],
+                'Called' => $leg['to'],
+                'CallStatus' => $status,
+            ],
+        );
+        $this->lastResponse->assertStatus(200);
+
+        return $this;
+    }
+
+    public function callerHangsUp(): self
+    {
+        $conference = $this->activeConference();
+        $this->twilio->removeConferenceParticipant($conference['friendlyName'], $this->callSid);
+
+        $this->lastResponse = $this->dispatchWebhook(
+            $conference['statusCallback'],
+            [
+                'StatusCallbackEvent' => 'participant-leave',
+                'FriendlyName' => $conference['friendlyName'],
+                'CallSid' => $this->callSid,
+            ],
+        );
+        $this->lastResponse->assertStatus(200);
+
+        return $this;
+    }
+
+    public function followCallerRedirect(): self
+    {
+        $update = $this->twilio->callUpdates[0] ?? null;
+        if ($update === null || !isset($update['url'])) {
+            throw new \RuntimeException('No call redirect was recorded.');
+        }
+
+        $this->lastResponse = $this->dispatchWebhook(
+            $update['url'],
+            [
+                'CallSid' => $this->callSid,
+                'Called' => $this->callData['Called'] ?? '',
+            ],
+        );
+        $this->lastResponse->assertStatus(200);
+
+        return $this;
+    }
+
+    /** @return array{friendlyName: string, statusCallback: string} */
+    private function activeConference(): array
+    {
+        if ($this->conferenceName === null || $this->conferenceStatusCallback === null) {
+            throw new \RuntimeException('No active conference found.');
+        }
+
+        return [
+            'friendlyName' => $this->conferenceName,
+            'statusCallback' => $this->conferenceStatusCallback,
+        ];
+    }
+
+    private function pendingLeg(int $n): array
+    {
+        $index = $n - 1;
+        if (!isset($this->twilio->pendingLegs[$index])) {
+            throw new \RuntimeException("No pending volunteer leg at index {$n}.");
+        }
+
+        return $this->twilio->pendingLegs[$index];
+    }
+
+    private function dispatchWebhook(string $url, array $params = []): TestResponse
+    {
+        [$path, $query] = $this->normalizeWebhookUrl($url);
+        $data = array_merge($this->callData, $query, $params);
+
+        return test()->call('GET', $path, $data);
+    }
+
+    /** @return array{0: string, 1: array<string, string>} */
+    private function normalizeWebhookUrl(string $url): array
+    {
+        if (!str_contains($url, '://')) {
+            $parts = parse_url($url);
+            $path = $parts['path'] ?? $url;
+            $query = [];
+            if (isset($parts['query'])) {
+                parse_str(html_entity_decode($parts['query']), $query);
+            }
+
+            return [$path, $query];
+        }
+
+        $parsed = parse_url($url);
+        $path = $parsed['path'] ?? '/';
+        $query = [];
+        if (isset($parsed['query'])) {
+            parse_str(html_entity_decode($parsed['query']), $query);
+        }
+
+        return [$path, $query];
+    }
+}

--- a/src/tests/Fakes/FakeTwilioAccount.php
+++ b/src/tests/Fakes/FakeTwilioAccount.php
@@ -341,7 +341,34 @@ class FakeTwilioAccount
                     'statusCallback' => 'status.php',
                 ];
 
-                return (object) $record;
+                return $this->account->hydrateIncomingPhoneNumber($record);
+            }
+        };
+    }
+
+    /**
+     * Twilio's IncomingPhoneNumberInstance stringifies to the E.164 number; the
+     * app logs it with sprintf("%s", $instance) in CallFlowController::index().
+     */
+    public function hydrateIncomingPhoneNumber(array $record): object
+    {
+        return new class ($record) {
+            public string $sid;
+
+            public string $phoneNumber;
+
+            public ?string $statusCallback;
+
+            public function __construct(array $record)
+            {
+                $this->sid = $record['sid'];
+                $this->phoneNumber = $record['phoneNumber'];
+                $this->statusCallback = $record['statusCallback'] ?? null;
+            }
+
+            public function __toString(): string
+            {
+                return $this->phoneNumber;
             }
         };
     }

--- a/src/tests/Fakes/FakeTwilioAccount.php
+++ b/src/tests/Fakes/FakeTwilioAccount.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace Tests\Fakes;
+
+use App\Constants\TwilioCallStatus;
+use DateTime;
+use Illuminate\Support\Str;
+
+/**
+ * Stateful in-memory Twilio account covering the REST surface the app touches.
+ * Duck-typed stdClass objects stand in for SDK instances.
+ */
+class FakeTwilioAccount
+{
+    /** @var array<string, array<string, mixed>> */
+    public array $calls = [];
+
+    /** @var array<string, array<string, mixed>> */
+    public array $conferences = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $messages = [];
+
+    /** @var list<array<string, mixed>> outbound legs created but not yet answered */
+    public array $pendingLegs = [];
+
+    /** @var list<array<string, mixed>> calls($sid)->update([...]) audit trail */
+    public array $callUpdates = [];
+
+    public int $conferenceReadsBeforeVisible = 0;
+
+    private int $conferenceReadCount = 0;
+
+    public function resetConferenceReadCount(): void
+    {
+        $this->conferenceReadCount = 0;
+    }
+
+    public function registerInboundCall(
+        string $callSid,
+        string $from,
+        string $to,
+        string $phoneNumberSid,
+    ): void {
+        $this->calls[$callSid] = [
+            'sid' => $callSid,
+            'to' => $to,
+            'from' => $from,
+            'status' => TwilioCallStatus::INPROGRESS,
+            'url' => null,
+            'statusCallback' => null,
+            'options' => [],
+            'startTime' => new DateTime('2023-01-26T18:00:00'),
+            'endTime' => new DateTime('2023-01-26T18:15:00'),
+            'phoneNumberSid' => $phoneNumberSid,
+        ];
+    }
+
+    public function registerIncomingPhoneNumber(
+        string $phoneNumberSid,
+        string $phoneNumber,
+        ?string $statusCallback = 'status.php',
+    ): void {
+        $this->incomingPhoneNumbers[$phoneNumberSid] = [
+            'sid' => $phoneNumberSid,
+            'phoneNumber' => $phoneNumber,
+            'statusCallback' => $statusCallback,
+        ];
+    }
+
+    /** @var array<string, array<string, mixed>> */
+    private array $incomingPhoneNumbers = [];
+
+    /** @var array<string, object> */
+    private array $phoneLookups = [];
+
+    public function setPhoneLookup(string $number, object $result): void
+    {
+        $this->phoneLookups[$number] = $result;
+    }
+
+    public function callList(): object
+    {
+        $account = $this;
+
+        return new class ($account) {
+            public function __construct(private FakeTwilioAccount $account)
+            {
+            }
+
+            public function create(string $to, string $from, array $options = []): object
+            {
+                $sid = 'CA' . Str::uuid()->toString();
+                $record = [
+                    'sid' => $sid,
+                    'to' => $to,
+                    'from' => $from,
+                    'status' => TwilioCallStatus::QUEUED,
+                    'url' => $options['url'] ?? null,
+                    'statusCallback' => $options['statusCallback'] ?? null,
+                    'options' => $options,
+                    'startTime' => new DateTime(),
+                    'endTime' => null,
+                    'phoneNumberSid' => null,
+                ];
+                $this->account->calls[$sid] = $record;
+                $this->account->pendingLegs[] = $record;
+
+                return (object) ['sid' => $sid];
+            }
+        };
+    }
+
+    public function callContext(string $sid): object
+    {
+        $account = $this;
+
+        return new class ($account, $sid) {
+            public function __construct(
+                private FakeTwilioAccount $account,
+                private string $sid,
+            ) {
+            }
+
+            public function fetch(): object
+            {
+                $call = $this->account->calls[$this->sid] ?? null;
+                if ($call === null) {
+                    throw new \RuntimeException("Unknown call sid: {$this->sid}");
+                }
+
+                return (object) $call;
+            }
+
+            public function update(array $data): object
+            {
+                $this->account->callUpdates[] = array_merge(['sid' => $this->sid], $data);
+                if (isset($this->account->calls[$this->sid])) {
+                    foreach ($data as $key => $value) {
+                        $this->account->calls[$this->sid][$key] = $value;
+                    }
+                }
+
+                return (object) ['sid' => $this->sid];
+            }
+        };
+    }
+
+    public function conferenceList(): object
+    {
+        $account = $this;
+
+        return new class ($account) {
+            public function __construct(private FakeTwilioAccount $account)
+            {
+            }
+
+            public function read(array $filters = []): array
+            {
+                $this->account->conferenceReadCount++;
+                if ($this->account->conferenceReadCount <= $this->account->conferenceReadsBeforeVisible) {
+                    return [];
+                }
+
+                $results = [];
+                foreach ($this->account->conferences as $sid => $conference) {
+                    if (isset($filters['friendlyName']) && $conference['friendlyName'] !== $filters['friendlyName']) {
+                        continue;
+                    }
+                    if (isset($filters['status']) && $conference['status'] !== $filters['status']) {
+                        continue;
+                    }
+                    $results[] = (object) [
+                        'sid' => $sid,
+                        'friendlyName' => $conference['friendlyName'],
+                        'status' => $conference['status'],
+                    ];
+                }
+
+                return $results;
+            }
+        };
+    }
+
+    public function conferenceContext(string $sid): object
+    {
+        $account = $this;
+
+        return new class ($account, $sid) {
+            public $participants;
+
+            public function __construct(
+                private FakeTwilioAccount $account,
+                private string $sid,
+            ) {
+                $this->participants = new class ($account, $sid) {
+                    public function __construct(
+                        private FakeTwilioAccount $account,
+                        private string $sid,
+                    ) {
+                    }
+
+                    public function read(): array
+                    {
+                        $conference = $this->account->conferences[$this->sid] ?? null;
+                        if ($conference === null) {
+                            return [];
+                        }
+
+                        return array_map(
+                            fn (array $participant) => (object) ['callSid' => $participant['callSid']],
+                            $conference['participants'],
+                        );
+                    }
+                };
+            }
+        };
+    }
+
+    public function createConference(string $friendlyName): string
+    {
+        $sid = 'CF' . Str::uuid()->toString();
+        $this->conferences[$sid] = [
+            'sid' => $sid,
+            'friendlyName' => $friendlyName,
+            'status' => 'in-progress',
+            'participants' => [],
+        ];
+
+        return $sid;
+    }
+
+    public function addConferenceParticipant(string $friendlyName, string $callSid): void
+    {
+        foreach ($this->conferences as &$conference) {
+            if ($conference['friendlyName'] !== $friendlyName) {
+                continue;
+            }
+            foreach ($conference['participants'] as $participant) {
+                if ($participant['callSid'] === $callSid) {
+                    return;
+                }
+            }
+            $conference['participants'][] = ['callSid' => $callSid];
+        }
+    }
+
+    public function removeConferenceParticipant(string $friendlyName, string $callSid): void
+    {
+        foreach ($this->conferences as &$conference) {
+            if ($conference['friendlyName'] !== $friendlyName) {
+                continue;
+            }
+            $conference['participants'] = array_values(array_filter(
+                $conference['participants'],
+                fn (array $participant) => $participant['callSid'] !== $callSid,
+            ));
+        }
+    }
+
+    public function conferenceSidForFriendlyName(string $friendlyName): ?string
+    {
+        foreach ($this->conferences as $sid => $conference) {
+            if ($conference['friendlyName'] === $friendlyName) {
+                return $sid;
+            }
+        }
+
+        return null;
+    }
+
+    public function messageList(): object
+    {
+        $account = $this;
+
+        return new class ($account) {
+            public function __construct(private FakeTwilioAccount $account)
+            {
+            }
+
+            public function create(string $to, array $options = []): object
+            {
+                $this->account->messages[] = [
+                    'to' => $to,
+                    'from' => $options['from'] ?? null,
+                    'body' => $options['body'] ?? null,
+                    'options' => $options,
+                ];
+
+                return (object) ['sid' => 'SM' . Str::uuid()->toString()];
+            }
+        };
+    }
+
+    public function lookupsV1(): object
+    {
+        $account = $this;
+
+        return new class ($account) {
+            public function __construct(private FakeTwilioAccount $account)
+            {
+            }
+
+            public function phoneNumbers(string $number): object
+            {
+                $account = $this->account;
+
+                return new class ($account, $number) {
+                    public function __construct(
+                        private FakeTwilioAccount $account,
+                        private string $number,
+                    ) {
+                    }
+
+                    public function fetch(): object
+                    {
+                        return $this->account->phoneLookups[$this->number]
+                            ?? (object) ['phoneNumber' => $this->number];
+                    }
+                };
+            }
+        };
+    }
+
+    public function incomingPhoneNumberContext(string $sid): object
+    {
+        $account = $this;
+
+        return new class ($account, $sid) {
+            public function __construct(
+                private FakeTwilioAccount $account,
+                private string $sid,
+            ) {
+            }
+
+            public function fetch(): object
+            {
+                $record = $this->account->incomingPhoneNumbers[$this->sid] ?? [
+                    'sid' => $this->sid,
+                    'phoneNumber' => '+12125551212',
+                    'statusCallback' => 'status.php',
+                ];
+
+                return (object) $record;
+            }
+        };
+    }
+
+    /** @return list<string> */
+    public function dialedNumbers(): array
+    {
+        return array_map(fn (array $leg) => $leg['to'], $this->pendingLegs);
+    }
+}

--- a/src/tests/Fakes/FakeTwilioAccount.php
+++ b/src/tests/Fakes/FakeTwilioAccount.php
@@ -36,6 +36,28 @@ class FakeTwilioAccount
         $this->conferenceReadCount = 0;
     }
 
+    public function recordConferenceRead(): bool
+    {
+        $this->conferenceReadCount++;
+
+        return $this->conferenceReadCount <= $this->conferenceReadsBeforeVisible;
+    }
+
+    /** @return array<string, mixed> */
+    public function incomingPhoneNumberRecord(string $sid): array
+    {
+        return $this->incomingPhoneNumbers[$sid] ?? [
+            'sid' => $sid,
+            'phoneNumber' => '+12125551212',
+            'statusCallback' => 'status.php',
+        ];
+    }
+
+    public function phoneLookupFor(string $number): object
+    {
+        return $this->phoneLookups[$number] ?? (object) ['phoneNumber' => $number];
+    }
+
     public function registerInboundCall(
         string $callSid,
         string $from,
@@ -157,8 +179,7 @@ class FakeTwilioAccount
 
             public function read(array $filters = []): array
             {
-                $this->account->conferenceReadCount++;
-                if ($this->account->conferenceReadCount <= $this->account->conferenceReadsBeforeVisible) {
+                if ($this->account->recordConferenceRead()) {
                     return [];
                 }
 
@@ -314,8 +335,7 @@ class FakeTwilioAccount
 
                     public function fetch(): object
                     {
-                        return $this->account->phoneLookups[$this->number]
-                            ?? (object) ['phoneNumber' => $this->number];
+                        return $this->account->phoneLookupFor($this->number);
                     }
                 };
             }
@@ -335,13 +355,9 @@ class FakeTwilioAccount
 
             public function fetch(): object
             {
-                $record = $this->account->incomingPhoneNumbers[$this->sid] ?? [
-                    'sid' => $this->sid,
-                    'phoneNumber' => '+12125551212',
-                    'statusCallback' => 'status.php',
-                ];
-
-                return $this->account->hydrateIncomingPhoneNumber($record);
+                return $this->account->hydrateIncomingPhoneNumber(
+                    $this->account->incomingPhoneNumberRecord($this->sid),
+                );
             }
         };
     }

--- a/src/tests/Feature/Scenarios/GenderRoutingScenarioTest.php
+++ b/src/tests/Feature/Scenarios/GenderRoutingScenarioTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Constants\CycleAlgorithm;
+use App\Constants\EventId;
+use App\Constants\VolunteerGender;
+use App\Constants\VolunteerRoutingType;
+use App\Models\ConfigData;
+use App\Services\RootServerService;
+use App\Structures\ServiceBodyCallHandling;
+use Tests\CallScenario;
+use Tests\FakeHttp;
+
+const SCENARIO_UNSPECIFIED_NUMBER = '(555) 111-0000';
+const SCENARIO_MALE_NUMBER = '(555) 111-0001';
+const SCENARIO_FEMALE_NUMBER = '(555) 111-0002';
+
+function scenarioVolunteer(string $name, string $phoneNumber, int $gender): array
+{
+    $shifts = [];
+    foreach (range(1, 7) as $day) {
+        $shifts[] = [
+            'day' => $day,
+            'tz' => 'America/New_York',
+            'start_time' => '12:00 AM',
+            'end_time' => '11:59 PM',
+        ];
+    }
+
+    return [
+        'volunteer_name' => $name,
+        'volunteer_phone_number' => $phoneNumber,
+        'volunteer_gender' => $gender,
+        'volunteer_responder' => 0,
+        'volunteer_notes' => '',
+        'volunteer_enabled' => true,
+        'volunteer_shift_schedule' => base64_encode(json_encode($shifts)),
+    ];
+}
+
+beforeEach(function () {
+    FakeHttp::install();
+
+    $this->serviceBodyId = '4400';
+    $this->caller = '+17325551212';
+    $this->called = '+12125551212';
+
+    $rootServer = mock(RootServerService::class)->makePartial();
+    $rootServer->shouldReceive('getServiceBody')
+        ->with($this->serviceBodyId)
+        ->andReturn((object) [
+            'id' => $this->serviceBodyId,
+            'parent_id' => '4399',
+            'name' => 'Scenario Test Area',
+            'helpline' => '',
+        ]);
+    app()->instance(RootServerService::class, $rootServer);
+
+    session()->put('override_service_body_id', $this->serviceBodyId);
+    session()->put('override_disable_postal_code_gather', true);
+
+    $callHandling = new ServiceBodyCallHandling();
+    $callHandling->volunteer_routing = VolunteerRoutingType::VOLUNTEERS;
+    $callHandling->service_body_id = (int) $this->serviceBodyId;
+    $callHandling->volunteer_routing_enabled = true;
+    $callHandling->gender_routing = 1;
+    $callHandling->call_strategy = CycleAlgorithm::LINEAR_CYCLE_AND_VOICEMAIL;
+
+    ConfigData::createServiceBodyCallHandling((int) $this->serviceBodyId, $callHandling);
+
+    ConfigData::createVolunteers((int) $this->serviceBodyId, [
+        scenarioVolunteer('Unspecified', SCENARIO_UNSPECIFIED_NUMBER, VolunteerGender::UNSPECIFIED),
+        scenarioVolunteer('Male', SCENARIO_MALE_NUMBER, VolunteerGender::MALE),
+        scenarioVolunteer('Female', SCENARIO_FEMALE_NUMBER, VolunteerGender::FEMALE),
+    ]);
+});
+
+test('caller gender selection routes to the matching volunteer through the live call path', function () {
+    $scenario = new CallScenario();
+
+    $scenario
+        ->startCall($this->caller, $this->called)
+        ->pressDigits('1')
+        ->followRedirect()
+        ->followRedirect()
+        ->pressDigits('2')
+        ->followRedirect();
+
+    expect($scenario->lastTwiml())->toDialConference();
+
+    $scenario->joinConference();
+
+    expect($scenario->twilio)->toHaveDialed(SCENARIO_FEMALE_NUMBER);
+
+    $scenario
+        ->answerVolunteer(1)
+        ->assertHasEvent(EventId::VOLUNTEER_IN_CONFERENCE);
+});

--- a/src/tests/Pest.php
+++ b/src/tests/Pest.php
@@ -6,8 +6,10 @@ use App\Services\TwilioService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Tests\Fakes\FakeTwilioAccount;
 use Tests\FakeTwilioHttpClient;
 use Tests\FakeTwilioUnauthorizedHttpClient;
+use Tests\Support\TwimlExpectations;
 use Tests\TestCase;
 use Tests\TwilioTestUtility;
 use Twilio\Rest\Client;
@@ -39,6 +41,48 @@ uses(TestCase::class, RefreshDatabase::class)
         expect(date_default_timezone_get())->toBe('UTC');
     })
     ->in('Feature');
+
+/**
+ * Opt-in Twilio harness: stateful FakeTwilioAccount wired through the same Client
+ * seam as setupTwilioService(), without disturbing per-test Mockery expectations
+ * in the legacy helpline tests.
+ *
+ * @return array{0: TwilioTestUtility, 1: FakeTwilioAccount}
+ */
+function setupFakeTwilioService(): array
+{
+    $utility = new TwilioTestUtility();
+    $account = new FakeTwilioAccount();
+    $fakeHttpClient = new FakeTwilioHttpClient();
+    $utility->client = mock('Twilio\Rest\Client', [
+        "username" => "fake",
+        "password" => "fake",
+        "httpClient" => $fakeHttpClient
+    ])->makePartial();
+
+    $utility->client->calls = $account->callList();
+    $utility->client->shouldReceive('calls')->andReturnUsing(
+        fn (string $sid) => $account->callContext($sid)
+    );
+    $utility->client->conferences = $account->conferenceList();
+    $utility->client->shouldReceive('conferences')->andReturnUsing(
+        fn (?string $sid = null) => $sid !== null ? $account->conferenceContext($sid) : $account->conferenceList()
+    );
+    $utility->client->messages = $account->messageList();
+    $utility->client->lookups = (object) ['v1' => $account->lookupsV1()];
+    $utility->client->shouldReceive('incomingPhoneNumbers')->andReturnUsing(
+        fn (string $sid) => $account->incomingPhoneNumberContext($sid)
+    );
+    $utility->client->shouldReceive('getAccountSid')->andReturn('AC123');
+
+    $utility->twilio = mock(TwilioService::class)->makePartial();
+    $utility->settings = app(SettingsService::class);
+    app()->instance(TwilioService::class, $utility->twilio);
+    $utility->twilio->shouldReceive('client')->withArgs([])->andReturn($utility->client);
+    $utility->twilio->shouldReceive('settings')->andReturn($utility->settings);
+
+    return [$utility, $account];
+}
 
 function setupTwilioService(): TwilioTestUtility
 {
@@ -86,6 +130,65 @@ function getSessionCookieValue($response)
 expect()->extend('hasQueryParam', function ($param, $pattern) {
     $queryString = Str::after($this->value, '?');
     return expect($queryString)->toMatch('/' . $param . '=' . $pattern . '/');
+});
+
+expect()->extend('toRedirectTo', function (string $uri) {
+    TwimlExpectations::assertRedirectsTo($this->value, $uri);
+
+    return $this;
+});
+
+expect()->extend('toGatherTo', function (string $action) {
+    TwimlExpectations::assertGathersTo($this->value, $action);
+
+    return $this;
+});
+
+expect()->extend('toDialConference', function (?string $conferenceName = null) {
+    TwimlExpectations::assertDialsConference($this->value, $conferenceName);
+
+    return $this;
+});
+
+expect()->extend('toHaveDialed', function (string ...$numbers) {
+    /** @var FakeTwilioAccount $account */
+    $account = $this->value;
+    foreach ($numbers as $number) {
+        expect($account->dialedNumbers())->toContain($number);
+    }
+
+    return $this;
+});
+
+expect()->extend('toHaveDialedInOrder', function (array $numbers) {
+    /** @var FakeTwilioAccount $account */
+    $account = $this->value;
+    expect($account->dialedNumbers())->toBe($numbers);
+
+    return $this;
+});
+
+expect()->extend('toHaveSentSms', function (string $to, ?string $bodyContains = null) {
+    /** @var FakeTwilioAccount $account */
+    $account = $this->value;
+    $match = collect($account->messages)->first(
+        fn (array $message) => $message['to'] === $to
+            && ($bodyContains === null || str_contains((string) $message['body'], $bodyContains))
+    );
+    expect($match)->not->toBeNull("Expected SMS to {$to}" . ($bodyContains ? " containing '{$bodyContains}'" : ''));
+
+    return $this;
+});
+
+expect()->extend('toHaveRedirectedCall', function (string $url) {
+    /** @var FakeTwilioAccount $account */
+    $account = $this->value;
+    $match = collect($account->callUpdates)->first(
+        fn (array $update) => isset($update['url']) && str_contains($update['url'], $url)
+    );
+    expect($match)->not->toBeNull("Expected a call redirect to URL containing '{$url}'");
+
+    return $this;
 });
 
 expect()->extend('toHaveUrlAndQueryStringMatching', function (string $baseUrl, array $expectedQuery) {

--- a/src/tests/Support/TwimlExpectations.php
+++ b/src/tests/Support/TwimlExpectations.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Support;
+
+use PHPUnit\Framework\Assert;
+
+class TwimlExpectations
+{
+    public static function assertRedirectsTo(string $twiml, string $uri): void
+    {
+        $xml = simplexml_load_string($twiml);
+        $redirectElements = $xml->xpath('//Redirect');
+        Assert::assertNotEmpty($redirectElements, 'Expected TwiML to contain <Redirect> tag');
+        Assert::assertSame($uri, (string) $redirectElements[0], "Expected Redirect to point to {$uri}, got " . (string) $redirectElements[0]);
+    }
+
+    public static function assertGathersTo(string $twiml, string $action): void
+    {
+        $xml = simplexml_load_string($twiml);
+        $elements = $xml->xpath('//Gather');
+        Assert::assertNotEmpty($elements, 'Expected TwiML to contain <Gather> tag');
+
+        $found = false;
+        foreach ($elements as $element) {
+            if ((string) $element['action'] === $action) {
+                $found = true;
+                break;
+            }
+        }
+
+        Assert::assertTrue($found, "Expected <Gather action=\"{$action}\"> but got:\n{$twiml}");
+    }
+
+    public static function assertDialsConference(string $twiml, ?string $conferenceName = null): string
+    {
+        $xml = simplexml_load_string($twiml);
+        $elements = $xml->xpath('//Conference');
+        Assert::assertNotEmpty($elements, "Expected TwiML to contain <Conference> but got:\n{$twiml}");
+
+        $name = trim((string) $elements[0]);
+        if ($conferenceName !== null) {
+            Assert::assertSame($conferenceName, $name, "Expected conference name {$conferenceName}, got {$name}");
+        }
+
+        return $name;
+    }
+
+    public static function getAttributeFromTag(string $twiml, string $tag, string $attribute): string
+    {
+        $xml = simplexml_load_string($twiml);
+        $elements = $xml->xpath('//' . $tag);
+        Assert::assertNotEmpty($elements, "Cannot find {$attribute} - no {$tag} tag found");
+        Assert::assertTrue(isset($elements[0][$attribute]), "Cannot find {$attribute} attribute in {$tag} tag");
+
+        return (string) $elements[0][$attribute];
+    }
+
+    public static function assertTwimlContains(string $twiml, string $tag, array $attributes = [], ?string $content = null): void
+    {
+        $xml = simplexml_load_string($twiml);
+        $elements = $xml->xpath('//' . $tag);
+        Assert::assertNotEmpty($elements, "Expected TwiML to contain <{$tag}> but got:\n{$twiml}");
+
+        if (empty($attributes) && $content === null) {
+            return;
+        }
+
+        $found = false;
+        foreach ($elements as $element) {
+            $elementAttributes = [];
+            foreach ($element->attributes() as $key => $value) {
+                $elementAttributes[$key] = (string) $value;
+            }
+
+            $matchesAttributes = empty($attributes) || empty(array_diff_assoc($attributes, $elementAttributes));
+            $matchesContent = $content === null || trim((string) $element) === $content;
+
+            if ($matchesAttributes && $matchesContent) {
+                $found = true;
+                break;
+            }
+        }
+
+        $errorMessage = "Expected <{$tag}>";
+        if (!empty($attributes)) {
+            $errorMessage .= ' with attributes ' . json_encode($attributes);
+        }
+        if ($content !== null) {
+            $errorMessage .= " containing text '{$content}'";
+        }
+        $errorMessage .= " but got:\n{$twiml}";
+
+        Assert::assertTrue($found, $errorMessage);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `FakeTwilioAccount` — a stateful in-memory Twilio account covering `calls->create()`, conference reads, SMS, lookups, and call updates
- Add `CallScenario` extending `TwilioCallTestBuilder` with `joinConference()`, volunteer outcome helpers, and webhook dispatch through the real IVR routes
- Add shared Pest expectations (`toHaveDialed`, `toDialConference`, etc.) and a gender-routing acceptance test in `Feature/Scenarios/` that asserts which volunteer number is dialed through the full call path

## Test plan

- [x] `FakeTwilioAccount` + `CallScenario` exist; no existing test files modified
- [x] Gender-routing scenario test asserts outbound dial side effects (not just TwiML)
- [ ] CI: `./vendor/bin/pest tests/Feature/Scenarios/GenderRoutingScenarioTest.php`
- [ ] Verify test fails on `main` without the #1594 gender-routing fix and passes on this branch

Closes #1581

Made with [Cursor](https://cursor.com)