### PR TITLE
fix: restore StirVerstat call-event logging dropped in 5.0 rewrite

### DIFF
--- a/src/app/Constants/EventId.php
+++ b/src/app/Constants/EventId.php
@@ -31,6 +31,7 @@ class EventId
     const VOLUNTEER_NUMBER_BAD = 26;
     const VOLUNTEER_NUMBER_BUSY = 27;
     const CUSTOM_EXTENSION = 28;
+    const STIR_VERSTAT_RECEIVED = 29;
 
     public static function getEventById($id)
     {
@@ -91,6 +92,8 @@ class EventId
                 return "Volunteer Number is Busy";
             case self::CUSTOM_EXTENSION:
                 return "Custom Extension";
+            case self::STIR_VERSTAT_RECEIVED:
+                return "STIR/SHAKEN Verification Status Received";
         }
     }
 }

--- a/src/app/Http/Controllers/CallFlowController.php
+++ b/src/app/Http/Controllers/CallFlowController.php
@@ -82,6 +82,13 @@ class CallFlowController extends Controller
             }
         }
 
+        if ($request->has('StirVerstat')) {
+            $this->call->insertCallEventRecord(
+                EventId::STIR_VERSTAT_RECEIVED,
+                (object)['stir_verstat' => $request->get('StirVerstat')]
+            );
+        }
+
         $digit = $this->call->getDigitResponse($request, 'language_selections', 'Digits');
 
         $twiml = new VoiceResponse();

--- a/src/tests/Feature/EventStatusTest.php
+++ b/src/tests/Feature/EventStatusTest.php
@@ -47,4 +47,5 @@ test('test event ids', function () {
     $this->assertTrue(EventId::getEventById(EventId::SPAD_LOOKUP) == "SPAD Lookup");
     $this->assertTrue(EventId::getEventById(EventId::SPAD_LOOKUP_SMS) == "SPAD Lookup via SMS");
     $this->assertTrue(EventId::getEventById(EventId::CUSTOM_EXTENSION) == "Custom Extension");
+    $this->assertTrue(EventId::getEventById(EventId::STIR_VERSTAT_RECEIVED) == "STIR/SHAKEN Verification Status Received");
 });

--- a/src/tests/Feature/StirVerstatTest.php
+++ b/src/tests/Feature/StirVerstatTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Constants\EventId;
+use App\Models\RecordEvent;
+use Tests\CallScenario;
+
+test('records StirVerstat call event on initial webhook', function ($method) {
+    $stirVerstat = 'TN-Validation-Passed-A';
+
+    $scenario = (new CallScenario([]))
+        ->withCallData(['StirVerstat' => $stirVerstat])
+        ->startCall('+17325551212', '+12125551212', $method)
+        ->assertHasEvent(EventId::STIR_VERSTAT_RECEIVED);
+
+    $event = RecordEvent::where('callsid', $scenario->getCallSid())
+        ->where('event_id', EventId::STIR_VERSTAT_RECEIVED)
+        ->first();
+
+    expect($event)->not->toBeNull();
+    expect(json_decode($event->meta, true))->toBe(['stir_verstat' => $stirVerstat]);
+})->with(['GET', 'POST']);


### PR DESCRIPTION
## Summary

- Restores `STIR_VERSTAT_RECEIVED` call-event recording on the initial call webhook when Twilio sends `StirVerstat`
- Reintroduces `EventId::STIR_VERSTAT_RECEIVED` (ID 29; `CUSTOM_EXTENSION` now occupies 28) with the original display name
- Adds a behavioral test asserting the event and `stir_verstat` metadata are persisted

Closes #1601

## Test plan

- [x] `vendor/bin/pest tests/Feature/StirVerstatTest.php`
- [x] `vendor/bin/pest tests/Feature/EventStatusTest.php`

Made with [Cursor](https://cursor.com)