### PR TITLE
fix: gate DatabaseMigrations on configured MySQL settings

### DIFF
--- a/src/app/Http/Middleware/DatabaseMigrations.php
+++ b/src/app/Http/Middleware/DatabaseMigrations.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use App\Services\SettingsService;
 use Closure;
-use Illuminate\Database\Migrations\MigrationRepository;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -24,7 +23,6 @@ class DatabaseMigrations
 
     public function __construct(
         private SettingsService $settings,
-        private MigrationRepository $migrationRepository,
     ) {
     }
 
@@ -62,10 +60,14 @@ class DatabaseMigrations
 
     public function migrationsShouldRun(): bool
     {
-        if (!Schema::hasTable(config('database.migrations'))) {
+        $table = config('database.migrations');
+
+        if (!Schema::hasTable($table)) {
             return true;
         }
 
-        return !in_array(self::LATEST_MIGRATION, $this->migrationRepository->getRan(), true);
+        return !DB::table($table)
+            ->where('migration', self::LATEST_MIGRATION)
+            ->exists();
     }
 }

--- a/src/app/Http/Middleware/DatabaseMigrations.php
+++ b/src/app/Http/Middleware/DatabaseMigrations.php
@@ -4,18 +4,28 @@ namespace App\Http\Middleware;
 
 use App\Services\SettingsService;
 use Closure;
+use Illuminate\Database\Migrations\MigrationRepository;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class DatabaseMigrations
 {
-    private SettingsService $settings;
+    /**
+     * Update this when adding a new migration so the middleware knows the schema
+     * is current and can skip calling Artisan on every request.
+     */
+    private const LATEST_MIGRATION = '2026_01_03_000000_create_chat_sessions_table';
 
-    public function __construct(SettingsService $settings)
-    {
-        $this->settings = $settings;
+    private const MIGRATION_LOCK_NAME = 'yap-db-migrations';
+
+    public function __construct(
+        private SettingsService $settings,
+        private MigrationRepository $migrationRepository,
+    ) {
     }
 
     /**
@@ -27,10 +37,35 @@ class DatabaseMigrations
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($this->settings->has('mysql_hostname')) {
-            Artisan::call("migrate", array('--force' => true));
+        if (!$this->isDatabaseConfigured()) {
+            return $next($request);
+        }
+
+        if ($this->migrationsShouldRun()) {
+            try {
+                ini_set('max_execution_time', '600');
+                DB::select('SELECT GET_LOCK(?, 600)', [self::MIGRATION_LOCK_NAME]);
+                Artisan::call('migrate', ['--force' => true]);
+            } finally {
+                DB::statement('SELECT RELEASE_LOCK(?)', [self::MIGRATION_LOCK_NAME]);
+            }
         }
 
         return $next($request);
+    }
+
+    public function isDatabaseConfigured(): bool
+    {
+        return !empty($this->settings->get('mysql_hostname'))
+            && !empty($this->settings->get('mysql_database'));
+    }
+
+    public function migrationsShouldRun(): bool
+    {
+        if (!Schema::hasTable(config('database.migrations'))) {
+            return true;
+        }
+
+        return !in_array(self::LATEST_MIGRATION, $this->migrationRepository->getRan(), true);
     }
 }

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -9,6 +9,9 @@
     <testsuite name="Feature">
       <directory>./tests/Feature</directory>
     </testsuite>
+    <testsuite name="Unit">
+      <directory>./tests/Unit</directory>
+    </testsuite>
   </testsuites>
   <coverage>
     <report>

--- a/src/tests/Pest.php
+++ b/src/tests/Pest.php
@@ -48,6 +48,9 @@ uses(TestCase::class, RefreshDatabase::class)
     })
     ->in('Feature');
 
+uses(TestCase::class)
+    ->in('Unit');
+
 /**
  * Opt-in Twilio harness: stateful FakeTwilioAccount wired through the same Client
  * seam as setupTwilioService(), without disturbing per-test Mockery expectations

--- a/src/tests/Unit/DatabaseMigrationsTest.php
+++ b/src/tests/Unit/DatabaseMigrationsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Http\Middleware\DatabaseMigrations;
+use App\Services\SettingsService;
+use Illuminate\Database\Migrations\MigrationRepository;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+function makeDatabaseMigrationsMiddleware(
+    SettingsService $settings,
+    ?MigrationRepository $repository = null,
+): DatabaseMigrations {
+    return new DatabaseMigrations(
+        $settings,
+        $repository ?? mock(MigrationRepository::class),
+    );
+}
+
+test('skips migrations when mysql hostname is empty', function () {
+    Artisan::spy();
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
+
+    $middleware = makeDatabaseMigrationsMiddleware($settings);
+    $called = false;
+
+    $middleware->handle(Request::create('/'), function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+    Artisan::shouldNotHaveReceived('call');
+});
+
+test('skips migrations when mysql database is empty', function () {
+    Artisan::spy();
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('');
+
+    $middleware = makeDatabaseMigrationsMiddleware($settings);
+    $called = false;
+
+    $middleware->handle(Request::create('/'), function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+    Artisan::shouldNotHaveReceived('call');
+});
+
+test('skips migrations when schema is up to date', function () {
+    Artisan::spy();
+    Schema::shouldReceive('hasTable')->with('migrations_v2')->andReturn(true);
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
+
+    $repository = mock(MigrationRepository::class);
+    $repository->shouldReceive('getRan')->andReturn([
+        '2026_01_03_000000_create_chat_sessions_table',
+    ]);
+
+    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $called = false;
+
+    $middleware->handle(Request::create('/'), function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+    Artisan::shouldNotHaveReceived('call');
+});
+
+test('runs migrations when configured and latest migration is missing', function () {
+    Artisan::shouldReceive('call')
+        ->once()
+        ->with('migrate', ['--force' => true]);
+    Schema::shouldReceive('hasTable')->with('migrations_v2')->andReturn(true);
+    DB::partialMock()
+        ->shouldReceive('select')
+        ->once()
+        ->with('SELECT GET_LOCK(?, 600)', ['yap-db-migrations'])
+        ->andReturn([(object) ['GET_LOCK(?)' => 1]])
+        ->shouldReceive('statement')
+        ->once()
+        ->with('SELECT RELEASE_LOCK(?)', ['yap-db-migrations']);
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
+
+    $repository = mock(MigrationRepository::class);
+    $repository->shouldReceive('getRan')->andReturn([
+        '2024_03_24_035821_create_config_table',
+    ]);
+
+    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $called = false;
+
+    $middleware->handle(Request::create('/'), function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+});
+
+test('runs migrations when configured and migrations table is missing', function () {
+    Artisan::shouldReceive('call')
+        ->once()
+        ->with('migrate', ['--force' => true]);
+    Schema::shouldReceive('hasTable')->with('migrations_v2')->andReturn(false);
+    DB::partialMock()
+        ->shouldReceive('select')
+        ->once()
+        ->with('SELECT GET_LOCK(?, 600)', ['yap-db-migrations'])
+        ->andReturn([(object) ['GET_LOCK(?)' => 1]])
+        ->shouldReceive('statement')
+        ->once()
+        ->with('SELECT RELEASE_LOCK(?)', ['yap-db-migrations']);
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
+
+    $repository = mock(MigrationRepository::class);
+    $repository->shouldNotReceive('getRan');
+
+    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $called = false;
+
+    $middleware->handle(Request::create('/'), function () use (&$called) {
+        $called = true;
+
+        return response('ok');
+    });
+
+    expect($called)->toBeTrue();
+});

--- a/src/tests/Unit/DatabaseMigrationsTest.php
+++ b/src/tests/Unit/DatabaseMigrationsTest.php
@@ -2,20 +2,24 @@
 
 use App\Http\Middleware\DatabaseMigrations;
 use App\Services\SettingsService;
-use Illuminate\Database\Migrations\MigrationRepository;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-function makeDatabaseMigrationsMiddleware(
-    SettingsService $settings,
-    ?MigrationRepository $repository = null,
-): DatabaseMigrations {
-    return new DatabaseMigrations(
-        $settings,
-        $repository ?? mock(MigrationRepository::class),
-    );
+function makeDatabaseMigrationsMiddleware(SettingsService $settings): DatabaseMigrations
+{
+    return new DatabaseMigrations($settings);
+}
+
+function mockLatestMigrationExists(bool $exists): void
+{
+    $query = mock(Builder::class);
+    $query->shouldReceive('where')->with('migration', '2026_01_03_000000_create_chat_sessions_table')->andReturnSelf();
+    $query->shouldReceive('exists')->andReturn($exists);
+
+    DB::shouldReceive('table')->with('migrations_v2')->andReturn($query);
 }
 
 test('skips migrations when mysql hostname is empty', function () {
@@ -61,17 +65,13 @@ test('skips migrations when mysql database is empty', function () {
 test('skips migrations when schema is up to date', function () {
     Artisan::spy();
     Schema::shouldReceive('hasTable')->with('migrations_v2')->andReturn(true);
+    mockLatestMigrationExists(true);
 
     $settings = mock(SettingsService::class);
     $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
     $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
 
-    $repository = mock(MigrationRepository::class);
-    $repository->shouldReceive('getRan')->andReturn([
-        '2026_01_03_000000_create_chat_sessions_table',
-    ]);
-
-    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $middleware = makeDatabaseMigrationsMiddleware($settings);
     $called = false;
 
     $middleware->handle(Request::create('/'), function () use (&$called) {
@@ -89,6 +89,7 @@ test('runs migrations when configured and latest migration is missing', function
         ->once()
         ->with('migrate', ['--force' => true]);
     Schema::shouldReceive('hasTable')->with('migrations_v2')->andReturn(true);
+    mockLatestMigrationExists(false);
     DB::partialMock()
         ->shouldReceive('select')
         ->once()
@@ -102,12 +103,7 @@ test('runs migrations when configured and latest migration is missing', function
     $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
     $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
 
-    $repository = mock(MigrationRepository::class);
-    $repository->shouldReceive('getRan')->andReturn([
-        '2024_03_24_035821_create_config_table',
-    ]);
-
-    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $middleware = makeDatabaseMigrationsMiddleware($settings);
     $called = false;
 
     $middleware->handle(Request::create('/'), function () use (&$called) {
@@ -132,15 +128,13 @@ test('runs migrations when configured and migrations table is missing', function
         ->shouldReceive('statement')
         ->once()
         ->with('SELECT RELEASE_LOCK(?)', ['yap-db-migrations']);
+    DB::shouldNotReceive('table');
 
     $settings = mock(SettingsService::class);
     $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
     $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap');
 
-    $repository = mock(MigrationRepository::class);
-    $repository->shouldNotReceive('getRan');
-
-    $middleware = makeDatabaseMigrationsMiddleware($settings, $repository);
+    $middleware = makeDatabaseMigrationsMiddleware($settings);
     $called = false;
 
     $middleware->handle(Request::create('/'), function () use (&$called) {


### PR DESCRIPTION
## Summary

- Replace `SettingsService::has('mysql_hostname')` with non-empty checks on `mysql_hostname` and `mysql_database`, matching the pattern used by `ValidateTwilioSignature`
- Only call `migrate` when the migrations table is missing or the latest migration has not run (avoids running Artisan on every request)
- Wrap the migrate call in a MySQL advisory lock to prevent concurrent migration runs
- Add unit tests covering skip and run paths for the middleware

Closes #1602

## Test plan

- [x] `./vendor/bin/pest tests/Unit/DatabaseMigrationsTest.php` passes
- [ ] Verify fresh install with empty `config.php` MySQL settings does not attempt migrations
- [ ] Verify configured instance auto-migrates after deploying a new migration file


Made with [Cursor](https://cursor.com)