### PR TITLE
Add yap:preflight command for pre-5.0 upgrade validation

### DIFF
--- a/src/app/Console/Commands/PreflightCommand.php
+++ b/src/app/Console/Commands/PreflightCommand.php
@@ -2,63 +2,45 @@
 
 namespace App\Console\Commands;
 
-use App\Services\SettingsService;
+use App\Services\Preflight\PreflightService;
 use Illuminate\Console\Command;
 
 class PreflightCommand extends Command
 {
     protected $signature = 'yap:preflight';
 
-    protected $description = 'Pre-deployment checks for Yap 5.x (Twilio signature validation, proxy config, required settings)';
+    protected $description = 'Validate environment and database readiness before upgrading to Yap 5.0';
 
-    public function handle(SettingsService $settings): int
+    public function handle(PreflightService $preflight): int
     {
-        $failed = false;
+        $result = $preflight->run();
 
-        if (empty($settings->get('twilio_auth_token'))) {
-            $failed = true;
-            $this->error(
-                'twilio_auth_token is empty. Yap 5.0 validates Twilio signatures on every inbound webhook and fails closed: '
-                . 'without an auth token, every call and SMS to the IVR returns HTTP 403. '
-                . 'Set $twilio_auth_token in config.php to the Auth Token for the Twilio account that owns your phone numbers.'
-            );
-        }
+        $this->info('Yap preflight checks');
+        $this->newLine();
 
-        if (config('twilio.disable_signature_validation') && !app()->environment('production')) {
-            $this->warn(
-                'TWILIO_DISABLE_SIGNATURE_VALIDATION is enabled. Signature checks are bypassed outside production only; '
-                . 'do not set this on a live helpline.'
-            );
-        }
+        foreach ($result['checks'] as $check) {
+            $status = $check['passed']
+                ? 'PASS'
+                : ($check['blocking'] ? 'FAIL' : 'WARN');
 
-        $trustedProxies = config('trustedproxy.proxies');
-        if (empty($trustedProxies)) {
-            $this->line(
-                'TRUSTED_PROXIES is not set (default). Direct connections and tests need no proxy trust. '
-                . 'If Yap sits behind ngrok, a load balancer, or another reverse proxy, set TRUSTED_PROXIES=* '
-                . 'or a comma-separated list of proxy IPs so Twilio signature validation sees the public URL Twilio signed.'
-            );
-        }
+            $this->line(sprintf('[%s] %s', $status, $check['label']));
+            $this->line('  ' . $check['message']);
 
-        foreach ($settings->minimalRequiredSettings() as $setting) {
-            if ($setting === 'twilio_auth_token') {
-                continue;
+            if (!$check['passed'] && !empty($check['remediation'])) {
+                $this->line('  → ' . $check['remediation']);
             }
 
-            if (!$settings->has($setting) || $settings->get($setting) === '') {
-                $failed = true;
-                $this->error("Missing required setting: {$setting}");
-            }
+            $this->newLine();
         }
 
-        if ($failed) {
-            $this->error('Preflight failed. Resolve the issues above before upgrading or taking traffic.');
+        if ($result['passed']) {
+            $this->info('All blocking preflight checks passed.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
-        $this->info('Preflight passed.');
+        $this->error('One or more blocking preflight checks failed. Resolve them before upgrading.');
 
-        return self::SUCCESS;
+        return self::FAILURE;
     }
 }

--- a/src/app/Services/Preflight/PreflightCheck.php
+++ b/src/app/Services/Preflight/PreflightCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\Preflight;
+
+class PreflightCheck
+{
+    public function __construct(
+        public string $id,
+        public string $label,
+        public bool $passed,
+        public string $message,
+        public ?string $remediation = null,
+        public bool $blocking = true,
+    ) {
+    }
+
+    public static function pass(
+        string $id,
+        string $label,
+        string $message,
+        bool $blocking = true,
+    ): self {
+        return new self($id, $label, true, $message, null, $blocking);
+    }
+
+    public static function fail(
+        string $id,
+        string $label,
+        string $message,
+        string $remediation,
+        bool $blocking = true,
+    ): self {
+        return new self($id, $label, false, $message, $remediation, $blocking);
+    }
+
+    public static function warn(
+        string $id,
+        string $label,
+        string $message,
+        string $remediation,
+    ): self {
+        return new self($id, $label, false, $message, $remediation, false);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'label' => $this->label,
+            'passed' => $this->passed,
+            'blocking' => $this->blocking,
+            'message' => $this->message,
+            'remediation' => $this->remediation,
+        ];
+    }
+}

--- a/src/app/Services/Preflight/PreflightService.php
+++ b/src/app/Services/Preflight/PreflightService.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace App\Services\Preflight;
+
+use App\Services\SettingsService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class PreflightService
+{
+    private const PHP_MIN_VERSION = '8.2.0';
+    private const PHP_DOCKER_VERSION = '8.5.0';
+    private const MYSQL_MIN_VERSION = '8.0.0';
+    private const MARIADB_MIN_VERSION = '10.3.0';
+
+    public function __construct(
+        private SettingsService $settings,
+    ) {
+    }
+
+    /**
+     * @return array{passed: bool, checks: array<int, array<string, mixed>>}
+     */
+    public function run(): array
+    {
+        $checks = [
+            $this->checkRequiredSettings(),
+            $this->checkTwilioAuthToken(),
+            $this->checkTwilioSignatureBypass(),
+            $this->checkTrustedProxies(),
+            $this->checkSessionDriver(),
+            $this->checkAppEnv(),
+            $this->checkPhpVersion(),
+            ...$this->checkDatabase(),
+        ];
+
+        $passed = collect($checks)->every(
+            fn (PreflightCheck $check) => $check->passed || !$check->blocking
+        );
+
+        return [
+            'passed' => $passed,
+            'checks' => array_map(fn (PreflightCheck $check) => $check->toArray(), $checks),
+        ];
+    }
+
+    /**
+     * @return list<PreflightCheck>
+     */
+    private function checkDatabase(): array
+    {
+        if (!$this->isDatabaseConfigured()) {
+            return [
+                PreflightCheck::fail(
+                    'database',
+                    'Database connection',
+                    'MySQL is not configured (mysql_hostname and mysql_database are required).',
+                    'Set mysql_hostname, mysql_username, mysql_password, and mysql_database in config.php.',
+                ),
+            ];
+        }
+
+        try {
+            DB::connection()->getPdo();
+        } catch (\Throwable $e) {
+            return [
+                PreflightCheck::fail(
+                    'database',
+                    'Database connection',
+                    'Unable to connect to MySQL: ' . $e->getMessage(),
+                    'Verify mysql_hostname, mysql_username, mysql_password, mysql_database, and mysql_port in config.php.',
+                ),
+            ];
+        }
+
+        $checks = [$this->checkMysqlVersion()];
+
+        if (!Schema::hasTable('users')) {
+            $checks[] = PreflightCheck::pass(
+                'users_table',
+                'Users table',
+                'Users table not found; skipping user-data checks (fresh install).',
+            );
+
+            return $checks;
+        }
+
+        return [
+            ...$checks,
+            $this->checkDuplicateUsernames(),
+            $this->checkEmptyUsernames(),
+            $this->checkUsersSchema(),
+        ];
+    }
+
+    private function checkDuplicateUsernames(): PreflightCheck
+    {
+        $duplicateUsernames = DB::select(
+            'SELECT username, COUNT(*) as cnt FROM users GROUP BY username HAVING cnt > 1'
+        );
+
+        if (count($duplicateUsernames) === 0) {
+            return PreflightCheck::pass(
+                'duplicate_usernames',
+                'Duplicate usernames',
+                'No duplicate usernames found.',
+            );
+        }
+
+        $examples = collect($duplicateUsernames)->pluck('username')->take(5)->implode(', ');
+
+        return PreflightCheck::fail(
+            'duplicate_usernames',
+            'Duplicate usernames',
+            sprintf('%d duplicate username value(s) found (e.g. %s).', count($duplicateUsernames), $examples),
+            'Resolve duplicate usernames before upgrading. The UUID migration reassigns user ids by username, so duplicates collide and break the primary key mid-migration.',
+        );
+    }
+
+    private function checkEmptyUsernames(): PreflightCheck
+    {
+        $nullOrEmptyUsername = DB::table('users')
+            ->where(function ($query) {
+                $query->whereNull('username')->orWhere('username', '');
+            })
+            ->count();
+
+        if ($nullOrEmptyUsername === 0) {
+            return PreflightCheck::pass(
+                'empty_usernames',
+                'Empty usernames',
+                'All users have a non-empty username.',
+            );
+        }
+
+        return PreflightCheck::fail(
+            'empty_usernames',
+            'Empty usernames',
+            sprintf('%d user(s) have a NULL or empty username.', $nullOrEmptyUsername),
+            'Assign a unique username to every user row before upgrading. Rows with NULL username keep id = NULL and the primary-key step of the UUID migration fails.',
+        );
+    }
+
+    private function checkUsersSchema(): PreflightCheck
+    {
+        $createTable = DB::selectOne('SHOW CREATE TABLE users');
+        $sql = $createTable->{'Create Table'};
+
+        if (!preg_match('/PRIMARY KEY\s*\(`id`\)/', $sql)) {
+            return PreflightCheck::fail(
+                'users_schema',
+                'Users table schema',
+                'users.id does not have a primary key.',
+                'Restore a PRIMARY KEY on users.id before upgrading. The UUID migration drops and recreates this key.',
+            );
+        }
+
+        if (!preg_match('/UNIQUE.*`username`/i', $sql)) {
+            return PreflightCheck::fail(
+                'users_schema',
+                'Users table schema',
+                'users.username does not have a unique index.',
+                'Add UNIQUE INDEX username_unique (username) on the users table before upgrading. Some older installs lack the index the migration assumes.',
+            );
+        }
+
+        return PreflightCheck::pass(
+            'users_schema',
+            'Users table schema',
+            'users.id has a primary key and users.username has a unique index.',
+        );
+    }
+
+    private function checkRequiredSettings(): PreflightCheck
+    {
+        $missing = [];
+        foreach ($this->settings->minimalRequiredSettings() as $setting) {
+            if ($setting === 'twilio_auth_token') {
+                continue;
+            }
+
+            if (!$this->settings->has($setting) || $this->settings->get($setting) === '') {
+                $missing[] = $setting;
+            }
+        }
+
+        if ($missing === []) {
+            return PreflightCheck::pass(
+                'required_settings',
+                'Required settings',
+                'All required config.php settings are present.',
+            );
+        }
+
+        return PreflightCheck::fail(
+            'required_settings',
+            'Required settings',
+            'Missing required setting(s): ' . implode(', ', $missing) . '.',
+            'Set each required value in config.php before upgrading.',
+        );
+    }
+
+    private function checkTwilioSignatureBypass(): PreflightCheck
+    {
+        if (!config('twilio.disable_signature_validation') || app()->environment('production')) {
+            return PreflightCheck::pass(
+                'twilio_signature_bypass',
+                'Twilio signature bypass',
+                'Twilio signature validation is not bypassed.',
+            );
+        }
+
+        return PreflightCheck::warn(
+            'twilio_signature_bypass',
+            'Twilio signature bypass',
+            'TWILIO_DISABLE_SIGNATURE_VALIDATION is enabled outside production.',
+            'Do not set TWILIO_DISABLE_SIGNATURE_VALIDATION on a live helpline.',
+        );
+    }
+
+    private function checkTrustedProxies(): PreflightCheck
+    {
+        $trustedProxies = config('trustedproxy.proxies');
+
+        if (!empty($trustedProxies)) {
+            return PreflightCheck::pass(
+                'trusted_proxies',
+                'Trusted proxies',
+                'TRUSTED_PROXIES is configured.',
+            );
+        }
+
+        return PreflightCheck::warn(
+            'trusted_proxies',
+            'Trusted proxies',
+            'TRUSTED_PROXIES is not set (default).',
+            'Direct connections need no proxy trust. If Yap sits behind ngrok, a load balancer, or another reverse proxy, set TRUSTED_PROXIES=* or a comma-separated list of proxy IPs so Twilio signature validation sees the public URL Twilio signed.',
+        );
+    }
+
+    private function checkTwilioAuthToken(): PreflightCheck
+    {
+        $token = $this->settings->get('twilio_auth_token');
+
+        if (!empty($token)) {
+            return PreflightCheck::pass(
+                'twilio_auth_token',
+                'Twilio auth token',
+                'twilio_auth_token is configured.',
+            );
+        }
+
+        return PreflightCheck::fail(
+            'twilio_auth_token',
+            'Twilio auth token',
+            'twilio_auth_token is missing or empty.',
+            'Set twilio_auth_token in config.php to the Auth Token for the Twilio account that owns your phone numbers. ValidateTwilioSignature rejects every IVR request with HTTP 403 when the token is empty, so all calls will fail.',
+        );
+    }
+
+    private function checkSessionDriver(): PreflightCheck
+    {
+        $driver = config('session.driver');
+
+        if ($driver !== 'database') {
+            return PreflightCheck::pass(
+                'session_driver',
+                'Session driver',
+                sprintf('SESSION_DRIVER is "%s".', $driver),
+            );
+        }
+
+        return PreflightCheck::fail(
+            'session_driver',
+            'Session driver',
+            'SESSION_DRIVER is set to "database".',
+            'Use file, redis, or another driver instead of database. config/session.php points at the sessions table, but Yap uses that table for call PINs (callsid, timestamp, pin), not Laravel sessions.',
+        );
+    }
+
+    private function checkAppEnv(): PreflightCheck
+    {
+        $env = config('app.env');
+
+        if ($env === 'production') {
+            return PreflightCheck::pass(
+                'app_env',
+                'APP_ENV',
+                'APP_ENV is "production".',
+            );
+        }
+
+        if (in_array($env, ['local', 'testing'], true)) {
+            return PreflightCheck::warn(
+                'app_env',
+                'APP_ENV',
+                sprintf('APP_ENV is "%s".', $env),
+                'Several security guards only apply the strict production behavior when APP_ENV is exactly "production". Set APP_ENV=production on live servers.',
+            );
+        }
+
+        return PreflightCheck::warn(
+            'app_env',
+            'APP_ENV',
+            sprintf('APP_ENV is "%s".', $env),
+            'Yap compares APP_ENV to the exact string "production" for security-sensitive behavior (for example Twilio signature validation bypass rules). Use APP_ENV=production on live servers unless you understand the implications.',
+        );
+    }
+
+    private function checkPhpVersion(): PreflightCheck
+    {
+        $current = PHP_VERSION;
+
+        if (version_compare($current, self::PHP_MIN_VERSION, '<')) {
+            return PreflightCheck::fail(
+                'php_version',
+                'PHP version',
+                sprintf('PHP %s is below the minimum %s required by composer.json.', $current, self::PHP_MIN_VERSION),
+                sprintf('Upgrade PHP to at least %s before deploying Yap 5.0.', self::PHP_MIN_VERSION),
+            );
+        }
+
+        if (version_compare($current, self::PHP_DOCKER_VERSION, '<')) {
+            return PreflightCheck::warn(
+                'php_version',
+                'PHP version',
+                sprintf('PHP %s meets the minimum (%s) but the official Docker image uses PHP %s.', $current, self::PHP_MIN_VERSION, self::PHP_DOCKER_VERSION),
+                sprintf('Consider upgrading to PHP %s to match the supported docker/Dockerfile image.', self::PHP_DOCKER_VERSION),
+            );
+        }
+
+        return PreflightCheck::pass(
+            'php_version',
+            'PHP version',
+            sprintf('PHP %s meets the minimum (%s) and matches the Docker image target.', $current, self::PHP_MIN_VERSION),
+        );
+    }
+
+    private function checkMysqlVersion(): PreflightCheck
+    {
+        $versionString = DB::selectOne('SELECT VERSION() as version')->version;
+        $version = $this->normalizeDatabaseVersion($versionString);
+
+        if (str_contains(strtolower($versionString), 'mariadb')) {
+            if (version_compare($version, self::MARIADB_MIN_VERSION, '<')) {
+                return PreflightCheck::fail(
+                    'mysql_version',
+                    'MySQL version',
+                    sprintf('MariaDB %s is below the minimum %s.', $version, self::MARIADB_MIN_VERSION),
+                    sprintf('Upgrade MariaDB to at least %s before deploying Yap 5.0.', self::MARIADB_MIN_VERSION),
+                );
+            }
+
+            return PreflightCheck::pass(
+                'mysql_version',
+                'MySQL version',
+                sprintf('MariaDB %s meets the minimum (%s).', $version, self::MARIADB_MIN_VERSION),
+            );
+        }
+
+        if (version_compare($version, self::MYSQL_MIN_VERSION, '<')) {
+            return PreflightCheck::fail(
+                'mysql_version',
+                'MySQL version',
+                sprintf('MySQL %s is below the minimum %s required by Laravel 12.', $version, self::MYSQL_MIN_VERSION),
+                sprintf('Upgrade MySQL to at least %s before deploying Yap 5.0.', self::MYSQL_MIN_VERSION),
+            );
+        }
+
+        return PreflightCheck::pass(
+            'mysql_version',
+            'MySQL version',
+            sprintf('MySQL %s meets the minimum (%s).', $version, self::MYSQL_MIN_VERSION),
+        );
+    }
+
+    private function normalizeDatabaseVersion(string $versionString): string
+    {
+        if (preg_match('/(\d+\.\d+\.\d+)/', $versionString, $matches)) {
+            return $matches[1];
+        }
+
+        return $versionString;
+    }
+
+    private function isDatabaseConfigured(): bool
+    {
+        return !empty($this->settings->get('mysql_hostname'))
+            && !empty($this->settings->get('mysql_database'));
+    }
+}

--- a/src/app/Services/UpgradeService.php
+++ b/src/app/Services/UpgradeService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Constants\AlertId;
+use App\Services\Preflight\PreflightService;
 use CurlException;
 use Exception;
 use Illuminate\Support\Facades\App;
@@ -18,6 +19,7 @@ class UpgradeService extends Service
     protected TimeZoneService $timeZone;
     protected ReportsService $reports;
     protected TwilioService $twilio;
+    protected PreflightService $preflight;
 
     public function __construct(
         RootServerService $rootServer,
@@ -25,6 +27,7 @@ class UpgradeService extends Service
         TimeZoneService $timeZone,
         ReportsService $reports,
         TwilioService $twilio,
+        PreflightService $preflight,
     ) {
         parent::__construct(App::make(SettingsService::class));
         $this->rootServer = $rootServer;
@@ -32,44 +35,51 @@ class UpgradeService extends Service
         $this->timeZone = $timeZone;
         $this->reports = $reports;
         $this->twilio = $twilio;
+        $this->preflight = $preflight;
     }
 
     public function getStatus()
     {
+        $preflight = $this->preflight->run();
+        $checks = $preflight['checks'];
+
+        if (!$preflight['passed']) {
+            $failedCheck = collect($checks)->first(
+                fn (array $check) => !$check['passed'] && $check['blocking']
+            );
+
+            return $this->getState(
+                false,
+                $failedCheck['message'] ?? 'Preflight checks failed.',
+                '',
+                $checks
+            );
+        }
+
         $warnings = "";
         foreach ($this->settings->minimalRequiredSettings() as $setting) {
             if (!$this->settings->has($setting) || $this->settings->get($setting) === '') {
-                return $this->getState(false, "Missing required setting: " . $setting);
+                return $this->getState(false, "Missing required setting: " . $setting, $warnings, $checks);
             }
-        }
-
-        if (empty($this->settings->get('twilio_auth_token'))) {
-            return $this->getState(
-                false,
-                'twilio_auth_token is empty. Yap 5.0 validates Twilio signatures on every inbound webhook and rejects '
-                . 'requests when no auth token is configured, so every call would return HTTP 403. '
-                . 'Set $twilio_auth_token in config.php before upgrading.',
-                $warnings,
-            );
         }
 
         $root_server_settings = $this->rootServer->getServerInfo();
 
         if (strpos($this->settings->getAdminBMLTRootServer(), 'index.php')) {
-            return $this->getState(false, "Your root server points to index.php. Please make sure to set it to just the root directory.", $warnings);
+            return $this->getState(false, "Your root server points to index.php. Please make sure to set it to just the root directory.", $warnings, $checks);
         }
 
         if (!isset($root_server_settings)) {
-            return $this->getState(false, "Your root server returned no server information.  Double-check that you have the right root server url.", $warnings);
+            return $this->getState(false, "Your root server returned no server information.  Double-check that you have the right root server url.", $warnings, $checks);
         } else {
             if ($root_server_settings[0]->semanticAdmin === "0") {
-                return $this->getState(false, "Your root server has semanticAdmin disabled, please enable it.  https://bmlt.app/semantic/semantic-administration/", $warnings);
+                return $this->getState(false, "Your root server has semanticAdmin disabled, please enable it.  https://bmlt.app/semantic/semantic-administration/", $warnings, $checks);
             }
         }
 
         foreach ($this->settings->get("digit_map_search_type") as $digit => $value) {
             if ($digit === 0) {
-                return $this->getState(false, "You cannot use 0 as an option for `digit_map_search_type`.", $warnings);
+                return $this->getState(false, "You cannot use 0 as an option for `digit_map_search_type`.", $warnings, $checks);
             }
         }
 
@@ -77,16 +87,16 @@ class UpgradeService extends Service
             $googleapi_settings = $this->geocoding->ping("91409");
 
             if ($googleapi_settings->status == "REQUEST_DENIED") {
-                return $this->getState(false, "Your Google Maps API key came back with the following error. " . $googleapi_settings->error_message. " Please make sure you have the Google Maps Geocoding API enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/", $warnings);
+                return $this->getState(false, "Your Google Maps API key came back with the following error. " . $googleapi_settings->error_message. " Please make sure you have the Google Maps Geocoding API enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/", $warnings, $checks);
             }
 
             $timezone_settings = $this->timeZone->getTimeZoneForCoordinates("34.2011137", "-118.475058");
 
             if ($timezone_settings->status == "REQUEST_DENIED") {
-                return $this->getState(false, "Your Google Maps API key came back with the following error. " . $timezone_settings->errorMessage. " Please make sure you have the Google Time Zone API enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/", $warnings);
+                return $this->getState(false, "Your Google Maps API key came back with the following error. " . $timezone_settings->errorMessage. " Please make sure you have the Google Time Zone API enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/", $warnings, $checks);
             }
         } catch (Exception $e) {
-            return $this->getState(false, "HTTP Error connecting to Google Maps API, check your network settings.", $warnings);
+            return $this->getState(false, "HTTP Error connecting to Google Maps API, check your network settings.", $warnings, $checks);
         }
 
         $alerts = $this->reports->getMisconfiguredPhoneNumbersAlerts(AlertId::STATUS_CALLBACK_MISSING);
@@ -106,24 +116,24 @@ class UpgradeService extends Service
                         && !strpos($number->voiceUrl, 'twiml')
                         && !strpos($number->voiceUrl, '/?')
                         && substr($number->voiceUrl, -1) !== "/") {
-                        return $this->getState(false, $number->phoneNumber . " webhook should end either with `/` or `/index.php`", $warnings);
+                        return $this->getState(false, $number->phoneNumber . " webhook should end either with `/` or `/index.php`", $warnings, $checks);
                     }
                 }
             }
         } catch (RestException $e) {
             if ($this->isAllowedError("twilioFakeCredentials")) {
-                return $this->getState(false, "Twilio Rest Error: " . $e->getMessage(), $warnings);
+                return $this->getState(false, "Twilio Rest Error: " . $e->getMessage(), $warnings, $checks);
             }
         } catch (ConfigurationException $e) {
             if ($this->isAllowedError("twilioMissingCredentials")) {
-                return $this->getState(false, "Twilio Configuration Error: " . $e->getMessage(), $warnings);
+                return $this->getState(false, "Twilio Configuration Error: " . $e->getMessage(), $warnings, $checks);
             }
         }
 
         if ($this->settings->has('smtp_host')) {
             foreach ($this->settings->emailSettings() as $setting) {
                 if (!$this->settings->has($setting)) {
-                    return $this->getState(false, "Missing required email setting: " . $setting, $warnings);
+                    return $this->getState(false, "Missing required email setting: " . $setting, $warnings, $checks);
                 }
             }
         }
@@ -132,10 +142,10 @@ class UpgradeService extends Service
             DB::select("select 1");
         }
 
-        return $this->getState(true, "Ready To Yap!", $warnings);
+        return $this->getState(true, "Ready To Yap!", $warnings, $checks);
     }
 
-    private function getState($status = null, $message = null, $warnings = "")
+    private function getState($status = null, $message = null, $warnings = "", array $checks = [])
     {
         try {
             $build = Storage::get("build.txt");
@@ -147,7 +157,8 @@ class UpgradeService extends Service
             "message"=>$message,
             "warnings"=>$warnings,
             "version"=>$this->settings->version(),
-            "build"=>str_replace("\n", "", $build)
+            "build"=>str_replace("\n", "", $build),
+            "checks"=>$checks,
         ];
     }
 

--- a/src/docs/docs/miscellaneous/upgrading-from-yap-4x-to-yap-5x.md
+++ b/src/docs/docs/miscellaneous/upgrading-from-yap-4x-to-yap-5x.md
@@ -9,13 +9,16 @@ Yap 5.0 validates [Twilio request signatures](https://www.twilio.com/docs/usage/
 
 1. **Set `twilio_auth_token` in `config.php`.** The middleware fails closed: if the auth token is missing or empty, every inbound Twilio request returns HTTP 403 and callers hear silence. Operators who never configured `twilio_auth_token` had a working 4.5.x and would have a completely dead 5.0.0.
 
-2. **Run the preflight check** from your Yap directory:
+2. **Run the preflight check** from your Yap directory against your 4.5.x database, before pointing traffic at the new code:
 
    ```bash
+   cd src
    php artisan yap:preflight
    ```
 
-   Also review `/api/v1/upgrade` in the admin UI — it now treats an empty `twilio_auth_token` as a hard failure.
+   This validates UUID migration blockers (duplicate/empty usernames, schema shape), required settings, `SESSION_DRIVER`, `APP_ENV`, and MySQL/PHP versions — issues that are too late to catch once HTTP traffic hits the new folder. See [Upgrading](./upgrading.md) for the full step-by-step procedure.
+
+   After deploying, review `/api/v1/upgrade` — it exposes the same `checks` array plus root-server, Google Maps, and Twilio webhook validations.
 
 3. **Configure trusted proxies if you use a reverse proxy, load balancer, or tunnel.** Twilio signs the public URL it calls. Yap validates against `$request->fullUrl()`, which only honors `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, and `X-Forwarded-Prefix` from **trusted** proxies.
 

--- a/src/docs/docs/miscellaneous/upgrading.md
+++ b/src/docs/docs/miscellaneous/upgrading.md
@@ -3,10 +3,54 @@ title: Upgrading
 sidebar_position: 7
 ---
 
----
+# Upgrading from Yap 4.x to Yap 5.x
 
-See [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x) for release-critical changes in 5.0 (Twilio signature validation, `TRUSTED_PROXIES`, and the `yap:preflight` check).
+See [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x) for release-critical changes in 5.0 (Twilio signature validation, `TRUSTED_PROXIES`, and related breaking changes).
 
-Make a new folder with the newer version and copy over the config.php.  Once you feel comfortable you can delete the older folder and rename it.
+Upgrading to Yap 5.0 includes a destructive UUID migration that runs automatically on the first HTTP request against the new code. Run preflight checks **before** pointing traffic at the new folder.
 
-Be sure to run the /api/v1/upgrade
+## Step 1: Run preflight against your 4.5.x database
+
+1. Create a new folder with the Yap 5.0 code.
+2. Copy `config.php` from your existing 4.5.x install into the new folder.
+3. From the new folder, run:
+
+```bash
+cd src
+php artisan yap:preflight
+```
+
+This command validates your database and environment **without booting the web stack**. It exits with a non-zero status when any blocking issue is found and prints remediation guidance for each check.
+
+Preflight validates:
+
+- Required `config.php` settings
+- Duplicate or empty `users.username` values (UUID migration blockers)
+- `users` primary key and `username` unique index shape
+- `twilio_auth_token` is present (empty token rejects every IVR call with HTTP 403)
+- `TRUSTED_PROXIES` when behind a reverse proxy (warning when unset)
+- `SESSION_DRIVER` is not `database` (Yap's `sessions` table stores call PINs, not Laravel sessions)
+- `APP_ENV` value (several guards compare against the exact string `production`)
+- MySQL and PHP versions against Yap 5.0 requirements
+
+Fix every `[FAIL]` result before continuing.
+
+## Step 2: Deploy the new folder
+
+Once preflight passes, copy over any other local customizations, update your web server to point at the new folder, and monitor the first requests.
+
+## Step 3: Confirm with the upgrade advisor
+
+After the upgrade, call the upgrade advisor to confirm runtime settings:
+
+```bash
+curl https://your-yap-host/api/v1/upgrade
+```
+
+The response includes the same `checks` array as `php artisan yap:preflight`, plus the existing root-server, Google Maps, and Twilio webhook validations.
+
+## General upgrade notes
+
+Make a new folder with the newer version and copy over `config.php`. Once you are comfortable you can delete the older folder and rename the new one.
+
+For upgrades from older major versions, see the dedicated guides in this section.

--- a/src/tests/Feature/PreflightTest.php
+++ b/src/tests/Feature/PreflightTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Services\GeocodingService;
+use App\Services\Preflight\PreflightService;
+use App\Services\SettingsService;
+use App\Services\TimeZoneService;
+use App\Services\TwilioService;
+use Illuminate\Support\Facades\DB;
+use Tests\FakeHttp;
+use Tests\FakeTwilioHttpClient;
+
+function insertLegacyPreflightUser(int $id, string $username): void
+{
+    DB::table('users')->insert([
+        'id' => $id,
+        'name' => 'Test User',
+        'username' => $username,
+        'password' => 'hash',
+        'permissions' => 0,
+        'is_admin' => 0,
+        'created_on' => now(),
+        'service_bodies' => null,
+    ]);
+}
+
+function setupUpgradeAdvisorMocks(): SettingsService
+{
+    FakeHttp::install();
+
+    $settingsService = app(SettingsService::class);
+    app()->instance(SettingsService::class, $settingsService);
+
+    $fakeHttpClient = new FakeTwilioHttpClient();
+    $twilioClient = mock('Twilio\Rest\Client', [
+        'username' => 'fake',
+        'password' => 'fake',
+        'httpClient' => $fakeHttpClient,
+    ])->makePartial();
+
+    $twilioService = mock(TwilioService::class)->makePartial();
+    $twilioService->shouldReceive('client')->withArgs([])->andReturn($twilioClient);
+    $twilioService->shouldReceive('settings')->andReturn($settingsService);
+    app()->instance(TwilioService::class, $twilioService);
+
+    $geocodingService = mock(GeocodingService::class)->makePartial();
+    $geocodingService
+        ->shouldReceive('ping')
+        ->withArgs(['91409'])
+        ->andReturn((object) ['status' => 'OK'])
+        ->zeroOrMoreTimes();
+    app()->instance(GeocodingService::class, $geocodingService);
+
+    $timezoneService = mock(TimeZoneService::class)->makePartial();
+    $timezoneService
+        ->shouldReceive('getTimeZoneForCoordinates')
+        ->withAnyArgs()
+        ->andReturn((object) ['status' => 'OK'])
+        ->zeroOrMoreTimes();
+    app()->instance(TimeZoneService::class, $timezoneService);
+
+    $twilioClient->shouldReceive('getAccountSid')->andReturn('123');
+    $incomingPhoneNumberContext = mock('\Twilio\Rest\Api\V2010\Account\InstanceContext');
+    $incomingPhoneNumberInstance = mock('\Twilio\Rest\Api\V2010\Account\IncomingPhoneNumberInstance');
+    $incomingPhoneNumberInstance->voiceUrl = 'http://localhost:3100/yap/index.php';
+    $incomingPhoneNumberContext->shouldReceive('read')->withNoArgs()
+        ->andReturn([$incomingPhoneNumberInstance])->zeroOrMoreTimes();
+    $twilioClient->incomingPhoneNumbers = $incomingPhoneNumberContext;
+
+    return $settingsService;
+}
+
+test('yap:preflight passes with a healthy database', function () {
+    insertLegacyPreflightUser(1, 'alice');
+    insertLegacyPreflightUser(2, 'bob');
+
+    $this->artisan('yap:preflight')
+        ->assertExitCode(0)
+        ->expectsOutputToContain('[PASS] Duplicate usernames')
+        ->expectsOutputToContain('[PASS] Twilio auth token');
+});
+
+test('yap:preflight fails on duplicate usernames', function () {
+    DB::statement('ALTER TABLE users DROP INDEX username_unique');
+    insertLegacyPreflightUser(10, 'dupe');
+    insertLegacyPreflightUser(11, 'dupe');
+
+    $this->artisan('yap:preflight')
+        ->assertExitCode(1)
+        ->expectsOutputToContain('[FAIL] Duplicate usernames')
+        ->expectsOutputToContain('Resolve duplicate usernames before upgrading');
+});
+
+test('yap:preflight fails on null username', function () {
+    insertLegacyPreflightUser(20, 'valid_user');
+    DB::statement('ALTER TABLE users MODIFY username VARCHAR(45) NULL');
+    DB::table('users')->insert([
+        'id' => 21,
+        'name' => 'Null Username',
+        'username' => null,
+        'password' => 'hash',
+        'permissions' => 0,
+        'is_admin' => 0,
+        'created_on' => now(),
+        'service_bodies' => null,
+    ]);
+
+    $this->artisan('yap:preflight')
+        ->assertExitCode(1)
+        ->expectsOutputToContain('[FAIL] Empty usernames');
+});
+
+test('yap:preflight fails when twilio auth token is missing', function () {
+    $settings = app(SettingsService::class);
+    $settings->set('twilio_auth_token', '');
+    app()->instance(SettingsService::class, $settings);
+
+    $this->artisan('yap:preflight')
+        ->assertExitCode(1)
+        ->expectsOutputToContain('[FAIL] Twilio auth token');
+});
+
+test('yap:preflight fails when session driver is database', function () {
+    config(['session.driver' => 'database']);
+
+    $this->artisan('yap:preflight')
+        ->assertExitCode(1)
+        ->expectsOutputToContain('[FAIL] Session driver');
+});
+
+test('preflight service reports missing users unique index', function () {
+    DB::statement('ALTER TABLE users DROP INDEX username_unique');
+    insertLegacyPreflightUser(30, 'solo_user');
+
+    $result = app(PreflightService::class)->run();
+    $schemaCheck = collect($result['checks'])->firstWhere('id', 'users_schema');
+
+    expect($result['passed'])->toBeFalse();
+    expect($schemaCheck['passed'])->toBeFalse();
+    expect($schemaCheck['remediation'])->toContain('username_unique');
+});
+
+test('upgrade endpoint includes preflight checks', function () {
+    insertLegacyPreflightUser(40, 'upgrade_check_user');
+    setupUpgradeAdvisorMocks();
+
+    $response = $this->get('/api/v1/upgrade');
+
+    $response
+        ->assertStatus(200)
+        ->assertJsonStructure([
+            'status',
+            'message',
+            'warnings',
+            'version',
+            'build',
+            'checks' => [
+                '*' => ['id', 'label', 'passed', 'blocking', 'message', 'remediation'],
+            ],
+        ]);
+
+    $checks = $response->json('checks');
+    expect(collect($checks)->pluck('id'))->toContain('duplicate_usernames', 'twilio_auth_token');
+});
+
+test('upgrade endpoint fails when preflight checks fail', function () {
+    $settings = setupUpgradeAdvisorMocks();
+    $settings->set('twilio_auth_token', '');
+    app()->instance(SettingsService::class, $settings);
+
+    $response = $this->get('/api/v1/upgrade');
+
+    $response
+        ->assertStatus(200)
+        ->assertJson([
+            'status' => false,
+        ]);
+
+    expect($response->json('checks'))->not->toBeEmpty();
+});

--- a/src/tests/Unit/PreflightCommandTest.php
+++ b/src/tests/Unit/PreflightCommandTest.php
@@ -2,14 +2,14 @@
 
 use App\Services\SettingsService;
 
-test('preflight warns when twilio_auth_token is empty', function () {
+test('preflight fails when twilio_auth_token is empty', function () {
     putenv('ENVIRONMENT=test');
     $settings = new SettingsService();
     $settings->set('twilio_auth_token', '');
     app()->instance(SettingsService::class, $settings);
 
     $this->artisan('yap:preflight')
-        ->expectsOutputToContain('twilio_auth_token')
+        ->expectsOutputToContain('[FAIL] Twilio auth token')
         ->assertFailed();
 });
 
@@ -19,5 +19,6 @@ test('preflight passes when twilio_auth_token is configured', function () {
     app()->instance(SettingsService::class, $settings);
 
     $this->artisan('yap:preflight')
+        ->expectsOutputToContain('[PASS] Twilio auth token')
         ->assertSuccessful();
 });

--- a/src/tests/Unit/PreflightServiceTest.php
+++ b/src/tests/Unit/PreflightServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Services\Preflight\PreflightService;
+use App\Services\SettingsService;
+
+test('preflight service fails when database is not configured', function () {
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('minimalRequiredSettings')->andReturn(['twilio_auth_token']);
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('');
+    $settings->shouldReceive('get')->with('twilio_auth_token')->andReturn('token');
+
+    $result = (new PreflightService($settings))->run();
+
+    expect($result['passed'])->toBeFalse();
+    expect(collect($result['checks'])->firstWhere('id', 'database')['passed'])->toBeFalse();
+});
+
+test('preflight service warns when app env is not production', function () {
+    config(['app.env' => 'staging']);
+
+    $settings = mock(SettingsService::class);
+    $settings->shouldReceive('minimalRequiredSettings')->andReturn(['twilio_auth_token']);
+    $settings->shouldReceive('get')->with('twilio_auth_token')->andReturn('token');
+    $settings->shouldReceive('get')->with('mysql_hostname')->andReturn('127.0.0.1');
+    $settings->shouldReceive('get')->with('mysql_database')->andReturn('yap_test');
+
+    $result = (new PreflightService($settings))->run();
+    $appEnvCheck = collect($result['checks'])->firstWhere('id', 'app_env');
+
+    expect($appEnvCheck['passed'])->toBeFalse();
+    expect($appEnvCheck['blocking'])->toBeFalse();
+});


### PR DESCRIPTION
Closes #1585

## Summary
- Adds `php artisan yap:preflight` to validate a 4.5.x database and environment before deploying Yap 5.0, without booting the web stack
- Surfaces the same checks in `GET /api/v1/upgrade` via a new `checks` array for post-upgrade confirmation
- Documents preflight as step 1 in the 4.x → 5.x upgrade guide

## Checks
- Duplicate / empty `users.username` values
- `users` primary key and `username` unique index shape
- `twilio_auth_token` present
- `SESSION_DRIVER` is not `database`
- `APP_ENV` value (warning when not `production`)
- MySQL version (8.0+ / MariaDB 10.3+)
- PHP version (8.2+ required, 8.5 recommended per Docker image)

## Test plan
- [x] `php artisan yap:preflight` passes against a healthy test database
- [x] Non-zero exit on duplicate usernames, null username, missing Twilio token, and `SESSION_DRIVER=database`
- [x] `/api/v1/upgrade` includes `checks` array and fails when preflight checks fail
- [ ] Run against a restored copy of a real 4.5.x production database (manual operator step)


Made with [Cursor](https://cursor.com)