### PR TITLE
security: restore throttle:api and audit Kernel middleware

### DIFF
--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -34,6 +34,26 @@ use Illuminate\View\Middleware\ShareErrorsFromSession;
 class Kernel extends HttpKernel
 {
     /**
+     * Run API throttling before authentication so unauthenticated bursts on
+     * auth:sanctum routes are rate-limited instead of returning 401 forever.
+     *
+     * @var array<int, class-string|string>
+     */
+    protected $middlewarePriority = [
+        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+        \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
+        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+        \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
+
+    /**
      * The application's global HTTP middleware stack.
      *
      * These middleware are run during every request to your application.
@@ -66,9 +86,12 @@ class Kernel extends HttpKernel
         'web' => [
             EncryptCookies::class,
             AddQueuedCookiesToResponse::class,
+            // StartSession also runs in the global stack; the middleware is
+            // idempotent and does not double-start or reset the session.
             StartSession::class,
-//            \Illuminate\Session\Middleware\AuthenticateSession::class,
-//            ShareErrorsFromSession::class,
+            // Off in 4.5.x; Sanctum bearer tokens are the primary API auth path.
+            // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            // ShareErrorsFromSession runs in the global stack instead.
             VerifyCsrfToken::class,
             SubstituteBindings::class,
             CallBlocklist::class,
@@ -76,8 +99,9 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-//            EnsureFrontendRequestsAreStateful::class,
-//            'throttle:api',
+            // SPA login uses session()->regenerate(); global StartSession covers API
+            // routes — EnsureFrontendRequestsAreStateful is not required today.
+            'throttle:api',
             SubstituteBindings::class,
         ],
     ];
@@ -90,12 +114,10 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        //'authForAdminPortal' => AdminAuthenticator::class,
+        // authForAdminPortal, auth.basic, and guest were removed — no routes reference them.
         'auth' => Authenticate::class,
-//        'auth.basic' => AuthenticateWithBasicAuth::class,
         'cache.headers' => SetCacheHeaders::class,
         'can' => Authorize::class,
-        //'guest' => RedirectIfAuthenticated::class,
         'password.confirm' => RequirePassword::class,
         'signed' => ValidateSignature::class,
         'throttle' => ThrottleRequests::class,

--- a/src/app/Providers/RouteServiceProvider.php
+++ b/src/app/Providers/RouteServiceProvider.php
@@ -58,7 +58,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting()
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60);
+            return Limit::perMinute(60)->by($request->ip());
         });
 
         // WebRTC token endpoint - configurable limit (default: 5/min)

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -16,7 +16,7 @@ Route::group([
     'namespace' => 'App\Http\Controllers\Api\V1\Admin',
 ], function () {
     Route::post('login', [AuthController::class, 'login'])
-        ->middleware('throttle:60,1')  // 60 attempts per minute
+        ->middleware('throttle:5,1')  // 5 credential attempts per minute (admin panel)
         ->name('login');
     Route::get('version', function (\App\Services\SettingsService $settings) {
         return response()->json(['version' => $settings->version()]);

--- a/src/tests/Feature/KernelMiddlewareTest.php
+++ b/src/tests/Feature/KernelMiddlewareTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+test('no route references a removed middleware alias', function () {
+    $removedAliases = ['authForAdminPortal', 'auth.basic', 'guest'];
+
+    foreach (Route::getRoutes() as $route) {
+        foreach ($route->gatherMiddleware() as $middleware) {
+            if (!is_string($middleware)) {
+                continue;
+            }
+
+            $alias = explode(':', $middleware, 2)[0];
+            expect($alias)->not->toBeIn(
+                $removedAliases,
+                sprintf(
+                    'Route %s %s references removed middleware alias %s',
+                    implode('|', $route->methods()),
+                    $route->uri(),
+                    $alias
+                )
+            );
+        }
+    }
+});
+
+test('every route middleware alias is registered', function () {
+    $router = app('router');
+    $registered = array_merge(
+        array_keys($router->getMiddleware()),
+        array_keys($router->getMiddlewareGroups())
+    );
+
+    foreach (Route::getRoutes() as $route) {
+        foreach ($route->gatherMiddleware() as $middleware) {
+            if (!is_string($middleware) || class_exists($middleware)) {
+                continue;
+            }
+
+            $alias = explode(':', $middleware, 2)[0];
+            expect($alias)->toBeIn(
+                $registered,
+                sprintf(
+                    'Route %s %s references unregistered middleware alias %s',
+                    implode('|', $route->methods()),
+                    $route->uri(),
+                    $alias
+                )
+            );
+        }
+    }
+});
+
+test('security: unauthenticated burst against auth:sanctum route is throttled', function () {
+    for ($i = 0; $i < 60; $i++) {
+        $this->getJson('/api/v1/users')->assertStatus(401);
+    }
+
+    $this->getJson('/api/v1/users')->assertStatus(429);
+});

--- a/src/tests/Feature/SecurityAuthenticationTest.php
+++ b/src/tests/Feature/SecurityAuthenticationTest.php
@@ -9,22 +9,22 @@ beforeAll(function () {
 
 beforeEach(function () {
     // Failed logins fall through to the BMLT root server. The rate-limit test
-    // below makes 60 of them, so this used to be 60 live POSTs per run.
+    // below makes several of them, so FakeHttp avoids live POSTs per run.
     FakeHttp::install();
 });
 
 test('security: rate limits after multiple failed login attempts', function () {
     User::saveUser('Test', 'testuser', 'correctpass', [], []);
 
-    // Attempt 60 rapid failed logins (rate limit is 60 per minute)
-    for ($i = 0; $i < 60; $i++) {
+    // Attempt 5 rapid failed logins (login route limit is 5 per minute)
+    for ($i = 0; $i < 5; $i++) {
         $this->post('/api/v1/login', [
             'username' => 'testuser',
             'password' => 'wrongpass'
         ]);
     }
 
-    // 61st attempt should be rate limited (429)
+    // 6th attempt should be rate limited (429)
     $response = $this->post('/api/v1/login', [
         'username' => 'testuser',
         'password' => 'correctpass'


### PR DESCRIPTION
Closes #1588

## Summary

- Restored `throttle:api` to the `api` middleware group so all API routes (including `auth:sanctum` endpoints) are rate-limited at 60 requests/minute per IP.
- Tightened `POST /api/v1/login` from 60 to **5 attempts/minute** — appropriate for a helpline admin panel and limits credential-stuffing risk.
- Reordered middleware priority so `ThrottleRequests` runs **before** authentication; Laravel's default order caused unauthenticated bursts on protected routes to return 401 indefinitely without ever hitting the rate limiter.
- Audited commented-out Kernel entries: documented deliberate omissions (`ShareErrorsFromSession`, `AuthenticateSession`, `EnsureFrontendRequestsAreStateful`, duplicate `StartSession`) and removed unused route-middleware aliases (`authForAdminPortal`, `auth.basic`, `guest`).
- Added `KernelMiddlewareTest` to assert no route references removed aliases, all route middleware aliases resolve, and unauthenticated bursts against `auth:sanctum` routes receive 429.

## Test plan

- [x] `pest tests/Feature/KernelMiddlewareTest.php`
- [x] `pest tests/Feature/SecurityAuthenticationTest.php`

Made with [Cursor](https://cursor.com)