### PR TITLE
Operator docs and UI: use upgrade advisor instead of CLI commands

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -45,6 +45,19 @@ To test building the docs run:
 npm run docusaurus build
 ```
 
+### Preflight checks (developers)
+
+Operators verify configuration through `GET /api/v1/upgrade` or the admin **System Health** page — no shell access required.
+
+For local development and CI, you can run the same blocking checks from the shell:
+
+```shell
+cd src
+php artisan yap:preflight
+```
+
+This exits non-zero when any blocking check fails. It is useful before cutting a release or testing an upgrade against a copy of production data.
+
 ### API Docs (WIP)
 
 This only works locally right now.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,7 +7,7 @@
 #### Breaking changes
 
 * **Laravel 10 → 12, PHP 8.2+.** `composer.json` requires `^8.2`; the official Docker image uses PHP 8.5. PHP 8.1 is no longer supported. MySQL 8.0+ (or MariaDB 10.3+) is required.
-* **Destructive UUID migration for `users.id`.** Integer user ids become UUIDs. Run `php artisan yap:preflight` before deploying; run `php artisan migrate` manually for the UUID step after backup. Safe migrations may auto-apply on the first HTTP request.
+* **Destructive UUID migration for `users.id`.** Integer user ids become UUIDs. Confirm upgrade advisor checks pass at `GET /api/v1/upgrade` (or **System Health** in the admin portal) before deploying; schedule the UUID migration with your server administrator after backup. Safe migrations may auto-apply on the first HTTP request.
 * **Twilio signature validation on all inbound webhooks.** Yap 5.0 validates `X-Twilio-Signature` on every Twilio-facing route (full IVR, SMS, voicemail, dialback, status callbacks). Validation fails closed: an empty `twilio_auth_token` or a URL/proxy mismatch causes HTTP 403 on every inbound call. [#1589]
 * **Trusted proxies are opt-in.** `TrustProxies` no longer defaults to `*`. Set `TRUSTED_PROXIES` when behind ngrok, a load balancer, or another reverse proxy so signature validation sees the public URL Twilio signed. [#1589]
 * **Do not use `SESSION_DRIVER=database`.** Yap's `sessions` table stores call PINs, not Laravel sessions.
@@ -18,7 +18,8 @@
 
 #### Features and fixes
 
-* **Upgrade advisor Twilio compliance checks.** `/api/v1/upgrade` and the admin dashboard now validate Twilio account type, US voice geo permissions, Trust Hub profile, A2P SMS brand registration, and toll-free verification — surfacing configuration issues that block volunteer outbound dialing or SMS meeting results before callers get stuck on hold. [#1615]
+* **Upgrade advisor Twilio compliance checks.** `/api/v1/upgrade` and the admin **Dashboard** / **System Health** pages now validate Twilio account type, US voice geo permissions, Trust Hub profile, A2P SMS brand registration, and toll-free verification — surfacing configuration issues that block volunteer outbound dialing or SMS meeting results before callers get stuck on hold. [#1615]
+* **Operator docs and admin UI use upgrade advisor instead of CLI.** Operator-facing documentation and the HTTP 503 migration page no longer instruct running `php artisan` commands. Preflight checks are surfaced on **Dashboard** and the new **System Health** page; `yap:preflight` remains documented for developers in `CONTRIBUTE.md`. [#1617]
 * **Fixed gender routing always dialing MALE volunteers.** A regression in the `$_SESSION` → `session()` rewrite turned the caller's gender selection into a boolean existence check, so on service bodies with `gender_routing_enabled` a caller who pressed 2 to speak to a woman — or 3 to speak to either — was routed to a male volunteer, and fell through to the fallback number or voicemail when no male volunteer was on shift. **`5.0.0-beta1` and `5.0.0-beta2` are affected**; upgrade if you use gender routing. [#1578]
 * **Fixed service-body override settings not seeding at login for database-authenticated admins.** A regression in the `$_SESSION` → `session()` rewrite passed the full service-body rights array to `setConfigForService()` on the V2 auth path instead of the first service-body id, so override settings never landed in the admin session and the settings UI showed global defaults for service-body admins. [#1579]
 * Fixed the WebChat volunteer SMS webhook (`/webchat-sms`) accepting and routing inbound messages even when WebChat was disabled. [#1577]
@@ -28,7 +29,7 @@
 * HTML formatted notifications for voicemail.
 * Added enabled field to volunteer CSV and JSON exports, with download buttons on Volunteers page [#1411]
 * Root service body admins can now access meeting request logs that have no service_body_id assigned [#1399]
-* **Legacy schema catch-up for long-running installs.** Upgrades from pre-Laravel databases automatically add missing columns (including `records_events.type` and `records.type`) on the first request or `php artisan migrate`. Manual `ALTER TABLE` is no longer required. [#1613]
+* **Legacy schema catch-up for long-running installs.** Upgrades from pre-Laravel databases automatically add missing columns (including `records_events.type` and `records.type`) on the first HTTP request. Manual `ALTER TABLE` is no longer required. [#1613]
 
 ### 4.5.0 (July 11, 2025)
 * Added new feature that allow for creating a custom prompt for language selection feature. [#1228]

--- a/src/docs/docs/general/01-setup.md
+++ b/src/docs/docs/general/01-setup.md
@@ -35,7 +35,7 @@ static $mysql_password = "";
 static $mysql_database = "";
 ```
 
-9. You can test whether or not you are properly configured by going to https://example.com/api/v1/upgrade.  On first deploy, safe schema migrations may run automatically on the first HTTP request; destructive migrations (such as the 4.x → 5.x UUID conversion) are blocked until you run `php artisan migrate` manually.  See [Upgrading from Yap 4.x to Yap 5.x](../miscellaneous/upgrading-from-yap-4x-to-yap-5x) for details.
+9. You can test whether or not you are properly configured by going to https://example.com/api/v1/upgrade.  On first deploy, safe schema migrations may run automatically on the first HTTP request; destructive migrations (such as the 4.x → 5.x UUID conversion) are blocked until a server administrator applies them.  See [Upgrading from Yap 4.x to Yap 5.x](../miscellaneous/upgrading-from-yap-4x-to-yap-5x) for details.  After logging in to the admin portal, **Dashboard** and **System Health** show the same upgrade advisor checks.
 
 10. Make a call to your number and try it out.  If there is a problem the debugger in the Twilio console will let you know why.  Most likely you did not setup your config.php file correctly.
 

--- a/src/docs/docs/general/php-requirements.md
+++ b/src/docs/docs/general/php-requirements.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Yap 5.0 runs on **PHP 8.2 or newer** with **MySQL 8.0+** (or MariaDB 10.3+) and an Apache-based web server with `mod_rewrite` enabled.
 
-Most install problems on shared Linux hosting come from **disabled PHP extensions**, not from missing Yap files. The upgrade advisor and `php artisan yap:preflight` check that required extensions are loaded.
+Most install problems on shared Linux hosting come from **disabled PHP extensions**, not from missing Yap files. The [upgrade advisor](https://yap.bmlt.app/miscellaneous/loggingdebugging#upgrade-advisor) checks that required extensions are loaded.
 
 ## Required PHP extensions
 
@@ -72,29 +72,15 @@ The official Yap Docker image (`docker/Dockerfile`) ships PHP 8.5 with `pdo`, `p
 
 ## Verify your server
 
-From SSH or your host's terminal:
+If your host provides a PHP info page or terminal, you can confirm the PHP version and loaded modules. Look for `fileinfo`, `pdo_mysql`, `curl`, `mbstring`, and `openssl`.
 
-```bash
-php -v
-php -m
+After Yap is deployed, open the upgrade advisor in your browser:
+
+```
+https://your-yap-host/api/v1/upgrade
 ```
 
-Look for `fileinfo`, `pdo_mysql`, `curl`, `mbstring`, and `openssl` in the `php -m` output.
-
-From a browser or curl after Yap is deployed:
-
-```bash
-curl https://your-yap-host/api/v1/upgrade
-```
-
-The `checks` array includes **PHP extensions** — any missing extension is listed with remediation text.
-
-Or run preflight before a 4.x → 5.x upgrade:
-
-```bash
-cd src
-php artisan yap:preflight
-```
+The `checks` array includes **PHP extensions** — any missing extension is listed with remediation text. You can also log in to the admin portal and open **Dashboard** or **System Health** for the same checks.
 
 ## Common errors
 

--- a/src/docs/docs/miscellaneous/docker-deployment.md
+++ b/src/docs/docs/miscellaneous/docker-deployment.md
@@ -24,8 +24,8 @@ The image installs `pdo`, `pdo_mysql`, and `mbstring`. Other required extensions
 
 ## Database
 
-Point `config.php` at your MySQL 8.0+ or MariaDB 10.3+ instance. Run `php artisan yap:preflight` and `php artisan migrate` from a shell in the container before sending live Twilio traffic at a 4.x → 5.x upgrade.
+Point `config.php` at your MySQL 8.0+ or MariaDB 10.3+ instance. Before sending live Twilio traffic at a 4.x → 5.x upgrade, open `https://your-yap-host/api/v1/upgrade` (or the admin **System Health** page) to confirm upgrade advisor checks pass. Destructive migrations still require a server administrator with shell access to the container.
 
 ## Upgrading
 
-Follow [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x) — back up the database, run preflight, then migrate manually during a maintenance window.
+Follow [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x) — back up the database, confirm upgrade advisor checks pass, then schedule the destructive UUID migration with whoever manages your server or container.

--- a/src/docs/docs/miscellaneous/loggingdebugging.md
+++ b/src/docs/docs/miscellaneous/loggingdebugging.md
@@ -17,7 +17,7 @@ Turn this off on production helplines once you have captured the issue.
 
 ## Laravel logs
 
-Yap writes Laravel logs to `src/storage/logs/laravel.log`. Check this file when the admin SPA or API returns 500 errors without detail in the browser.
+Yap writes Laravel logs to `src/storage/logs/laravel.log`. Check this file when the admin SPA or API returns 500 errors without detail in the browser. On shared hosting you may need to use your provider's file manager or log viewer to read this path.
 
 ## Twilio debugger
 
@@ -26,12 +26,14 @@ The Twilio Console **Monitor → Logs → Errors** page shows webhook failures (
 Common Twilio issues:
 
 - **HTTP 403 on every call** — empty `twilio_auth_token`, or `TRUSTED_PROXIES` unset behind a reverse proxy.
-- **HTTP 503 Database Upgrade Required** — run `php artisan migrate` after a major upgrade.
+- **HTTP 503 Database Upgrade Required** — a destructive database migration is pending after a major upgrade. Contact your server administrator or hosting provider to apply it during a maintenance window. See [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x).
 - **Silent hang-ups** — check `laravel.log` and Twilio's request inspector for the call SID.
 
 ## Upgrade advisor
 
-`GET /api/v1/upgrade` (or `php artisan yap:preflight` before deploy) validates configuration, database shape, Twilio webhooks, and Google Maps connectivity. Use it after any config change.
+`GET /api/v1/upgrade` validates configuration, database shape, Twilio webhooks, Google Maps connectivity, and Twilio compliance settings. Use it after any config change.
+
+Open the URL in a browser, or log in to the admin portal and review **Dashboard** or **System Health**. No shell access is required.
 
 ## Call-flow tracing
 

--- a/src/docs/docs/miscellaneous/upgrading-from-yap-4x-to-yap-5x.md
+++ b/src/docs/docs/miscellaneous/upgrading-from-yap-4x-to-yap-5x.md
@@ -9,10 +9,10 @@ Yap 5.0 is a major release for self-hosted operators. It upgrades Laravel 10 →
 
 ## 1. Back up your database
 
-Take a full MySQL/MariaDB backup **before** you upload the new code or run any migration. `php artisan migrate:rollback` is not a supported recovery path for production:
+Take a full MySQL/MariaDB backup **before** you upload the new code or run any migration. Rolling back the UUID migration is not a supported recovery path for production:
 
 - The UUID migration rewrites every row in `users` and changes the primary key type.
-- If anything goes wrong mid-migration, restore from **your** backup — not from `migrate:rollback`.
+- If anything goes wrong mid-migration, restore from **your** backup.
 - The migration creates a `users_pre_uuid_backup` table during `up()` as an emergency artifact, but you should not treat that as your upgrade rollback plan.
 
 ## 2. Migrations and the first HTTP request
@@ -22,13 +22,13 @@ Yap runs database migrations from the web middleware on incoming requests (see `
 | Migration type | Behavior on first HTTP request |
 |---|---|
 | **Safe** (schema additions, indexes, new tables) | Applied automatically on the first request that reaches the new code. |
-| **Destructive** (UUID conversion of `users.id`) | **Blocked.** Every web request returns HTTP 503 with a "Database Upgrade Required" page until you run `php artisan migrate` manually from a shell. |
+| **Destructive** (UUID conversion of `users.id`) | **Blocked.** Every web request returns HTTP 503 with a "Database Upgrade Required" page until a server administrator applies the migration from a shell. |
 
 **Take the site down or block traffic** until you have:
 
 1. A verified database backup.
-2. Run `php artisan yap:preflight` successfully (see below).
-3. A maintenance window to run `php artisan migrate` when you are ready for the UUID conversion.
+2. Upgrade advisor checks passing (see section 3).
+3. A maintenance window scheduled with your server administrator or hosting provider for the UUID conversion.
 
 Do not let Twilio webhooks or operators hit the new folder until you are prepared. Even "safe" auto-migrations modify your database on the first request.
 
@@ -36,23 +36,27 @@ Do not let Twilio webhooks or operators hit the new folder until you are prepare
 
 1. Create a new folder with the Yap 5.0 code.
 2. Copy `config.php` from your 4.5.x install.
-3. Run preflight (step 3 below).
-4. Point your web server at the new folder **only after** preflight passes.
-5. Run `cd src && php artisan migrate` to apply the UUID migration.
-6. Confirm with `GET /api/v1/upgrade`.
+3. Run upgrade advisor checks (section 3 below).
+4. Point your web server at the new folder **only after** upgrade advisor checks pass.
+5. Ask your server administrator to apply the destructive UUID migration during your maintenance window.
+6. Confirm with `GET /api/v1/upgrade` or the admin **System Health** page.
 
 See also [Upgrading](./upgrading.md) for the step-by-step checklist.
 
-## 3. Run `php artisan yap:preflight` before deploying
+## 3. Run upgrade advisor checks before deploying
 
 From the **new** Yap 5.0 folder, with your existing `config.php` pointing at your production database:
 
-```bash
-cd src
-php artisan yap:preflight
+1. Point a staging URL or temporary vhost at the new folder so you can reach it over HTTPS without live Twilio traffic.
+2. Open the upgrade advisor in your browser:
+
+```
+https://your-staging-host/api/v1/upgrade
 ```
 
-Preflight validates your environment and database **without serving web traffic**. It exits with a non-zero status when any blocking check fails and prints remediation guidance for each one.
+Or log in to `/admin` and open **Dashboard** or **System Health**.
+
+The upgrade advisor validates your environment and database over HTTP. It lists each check with status `pass`, `warn`, `fail`, or `skip`, plus remediation text for failures.
 
 | Check | Blocking? | What it means |
 |---|---|---|
@@ -69,7 +73,7 @@ Preflight validates your environment and database **without serving web traffic*
 | **Empty usernames** | FAIL | One or more `users` rows have NULL or empty `username`. |
 | **Users table schema** | FAIL | `users.id` lacks a primary key, or `users.username` lacks a unique index. |
 
-Fix every `[FAIL]` before continuing. After deploy, `GET /api/v1/upgrade` returns the same `checks` array plus root-server, Google Maps, Twilio webhook, and Twilio compliance validations (US voice geo permissions, Trust Hub, A2P SMS registration, toll-free verification).
+Fix every `fail` result before continuing. After deploy, `GET /api/v1/upgrade` and the admin **System Health** page return the same `checks` array plus root-server, Google Maps, Twilio webhook, and Twilio compliance validations (US voice geo permissions, Trust Hub, A2P SMS registration, toll-free verification).
 
 ## 4. `twilio_auth_token` is now required
 
@@ -81,7 +85,7 @@ Yap 4.5.x did **not** validate Twilio request signatures. Yap 5.0 validates `X-T
 - A missing or invalid signature → HTTP **403**.
 - A URL mismatch (proxy/host/scheme) → HTTP **403** (same total outage).
 
-Set `twilio_auth_token` in `config.php` to the Auth Token for the Twilio account that owns your phone numbers. Run preflight to confirm it is present before you deploy.
+Set `twilio_auth_token` in `config.php` to the Auth Token for the Twilio account that owns your phone numbers. Confirm it is present in the upgrade advisor before you deploy.
 
 ### Reverse proxies and `TRUSTED_PROXIES`
 
@@ -111,7 +115,7 @@ Helplines that resolve the service body later in the IVR (without `override_serv
 
 The migration `2025_01_01_163927_convert_id_to_guid_in_users_table` replaces integer `users.id` values with UUIDs. Any external reporting script, BI export, or custom integration that joins on the integer id **breaks** after upgrade.
 
-- Preflight checks for duplicate and empty usernames before the migration runs.
+- Upgrade advisor checks for duplicate and empty usernames before the migration runs.
 - Sanctum API tokens reference `tokenable_id` as a UUID after upgrade.
 - If you store Yap user ids anywhere outside Yap, plan to re-map them or switch to username as the stable key.
 
@@ -122,7 +126,7 @@ Laravel's `config/session.php` defaults to the `file` driver, which masks a nami
 - Laravel expects a `sessions` table for `SESSION_DRIVER=database`.
 - Yap's `sessions` table stores **call PINs** (`callsid`, `timestamp`, `pin`) for dialback — not Laravel admin sessions.
 
-If you set `SESSION_DRIVER=database`, Laravel will read and write the wrong table. Use `file` (default), `redis`, or another driver. Preflight fails if `SESSION_DRIVER=database`.
+If you set `SESSION_DRIVER=database`, Laravel will read and write the wrong table. Use `file` (default), `redis`, or another driver. Upgrade advisor fails if `SESSION_DRIVER=database`.
 
 ## 7. Removed and moved routes
 
@@ -180,7 +184,7 @@ Yap 5.0 serves the admin portal as a single-page application at `/admin` (and su
 - Their routes are **not registered** — every WebChat/WebRTC endpoint returns **404**.
 - Do not enable them on a production helpline in 5.0.0; they ship without test coverage and behavior may change.
 
-If you toggle either setting and have run `php artisan route:cache`, run `php artisan route:clear` for the change to take effect.
+On typical shared-hosting deployments, route changes take effect on the next request. If your server administrator uses Laravel route caching, they must clear the route cache after toggling these settings.
 
 ## 12. Custom extensions: volunteer data shape change
 
@@ -207,8 +211,12 @@ Beta releases did not document these breaking changes. See [RELEASENOTES.md](htt
 
 ## After upgrading
 
-```bash
-curl https://your-yap-host/api/v1/upgrade
+Open the upgrade advisor:
+
+```
+https://your-yap-host/api/v1/upgrade
 ```
 
-Confirm all preflight checks pass, Twilio webhooks validate, and the admin UI loads. Place a test call through your full IVR path (including gender routing, if enabled) before reopening traffic.
+Or review **System Health** in the admin portal after login.
+
+Confirm all upgrade advisor checks pass, Twilio webhooks validate, and the admin UI loads. Place a test call through your full IVR path (including gender routing, if enabled) before reopening traffic.

--- a/src/docs/docs/miscellaneous/upgrading.md
+++ b/src/docs/docs/miscellaneous/upgrading.md
@@ -7,22 +7,24 @@ sidebar_position: 7
 
 See [Upgrading from Yap 4.x to Yap 5.x](./upgrading-from-yap-4x-to-yap-5x) for release-critical changes in 5.0 (Twilio signature validation, `TRUSTED_PROXIES`, and related breaking changes).
 
-Upgrading to Yap 5.0 includes a destructive UUID migration that is **blocked** until you run `php artisan migrate` manually. Safe schema migrations may run automatically on the first HTTP request; the UUID conversion returns HTTP 503 until you migrate. Run preflight checks **before** pointing traffic at the new folder.
+Upgrading to Yap 5.0 includes a destructive UUID migration that is **blocked** until a server administrator applies it. Safe schema migrations may run automatically on the first HTTP request; the UUID conversion returns HTTP 503 until the destructive migration completes. Run upgrade advisor checks **before** pointing traffic at the new folder.
 
-## Step 1: Run preflight against your 4.5.x database
+## Step 1: Run upgrade advisor checks against your 4.5.x database
 
 1. Create a new folder with the Yap 5.0 code.
 2. Copy `config.php` from your existing 4.5.x install into the new folder.
-3. From the new folder, run:
+3. Point a **staging URL** or temporary vhost at the new folder (or ask your host to do this) so you can reach Yap over HTTPS without sending live Twilio traffic there yet.
+4. Open the upgrade advisor in your browser:
 
-```bash
-cd src
-php artisan yap:preflight
+```
+https://your-staging-host/api/v1/upgrade
 ```
 
-This command validates your database and environment **without booting the web stack**. It exits with a non-zero status when any blocking issue is found and prints remediation guidance for each check.
+Or log in to the admin portal and open **Dashboard** or **System Health** — both show the same `checks` list from the upgrade advisor.
 
-Preflight validates:
+The upgrade advisor validates your database and environment over HTTP. It reports blocking issues and remediation guidance for each check.
+
+Upgrade advisor checks include:
 
 - Required `config.php` settings
 - Duplicate or empty `users.username` values (UUID migration blockers)
@@ -34,21 +36,21 @@ Preflight validates:
 - `APP_ENV` value (several guards compare against the exact string `production`)
 - MySQL and PHP versions against Yap 5.0 requirements
 
-Fix every `[FAIL]` result before continuing.
+Fix every check with status `fail` before continuing.
 
 ## Step 2: Deploy the new folder
 
-Once preflight passes, copy over any other local customizations, update your web server to point at the new folder, and monitor the first requests.
+Once upgrade advisor checks pass, copy over any other local customizations, update your web server to point at the new folder, and monitor the first requests.
 
-## Step 3: Confirm with the upgrade advisor
+## Step 3: Confirm with the upgrade advisor after deploy
 
-After the upgrade, call the upgrade advisor to confirm runtime settings:
+After the upgrade, open the upgrade advisor again to confirm runtime settings:
 
-```bash
-curl https://your-yap-host/api/v1/upgrade
+```
+https://your-yap-host/api/v1/upgrade
 ```
 
-The response includes the same `checks` array as `php artisan yap:preflight` (with `status` values of `pass`, `warn`, `fail`, or `skip`), plus root-server, Google Maps, Twilio webhook, and **Twilio compliance** validations (account type, US voice geo permissions, Trust Hub profile, A2P SMS brand registration, and toll-free verification).
+The response includes a `checks` array (with `status` values of `pass`, `warn`, `fail`, or `skip`), plus root-server, Google Maps, Twilio webhook, and **Twilio compliance** validations (account type, US voice geo permissions, Trust Hub profile, A2P SMS brand registration, and toll-free verification). The admin **Dashboard** and **System Health** pages show the same checks after you log in.
 
 ## General upgrade notes
 

--- a/src/resources/js/components/App.js
+++ b/src/resources/js/components/App.js
@@ -8,6 +8,7 @@ import AssessmentIcon from '@mui/icons-material/Assessment';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import VolunteerActivismIcon from '@mui/icons-material/VolunteerActivism';
 import Diversity1Icon from '@mui/icons-material/Diversity1';
+import HealthAndSafetyIcon from '@mui/icons-material/HealthAndSafety';
 import {
     createBrowserRouter,
     Outlet, RouterProvider,
@@ -18,6 +19,7 @@ import Layout from "../layouts/Layout"
 import ServiceBodies from "../pages/ServiceBodies";
 import Schedules from "../pages/Schedules";
 import Dashboard from "../pages/Dashboard";
+import SystemHealth from "../pages/SystemHealth";
 import Reports from "../pages/Reports";
 import Volunteers from "../pages/Volunteers";
 import Groups from "../pages/Groups";
@@ -47,6 +49,11 @@ function AppContent({ session, authentication, router, showPasswordDialog, setSh
             segment: 'dashboard',
             title: getWord('dashboard') || 'Dashboard',
             icon: <DashboardIcon />
+        },
+        {
+            segment: 'systemHealth',
+            title: getWord('system_health') || 'System Health',
+            icon: <HealthAndSafetyIcon />
         },
         {
             segment: 'reports',
@@ -179,6 +186,10 @@ if (document.getElementById('root')) {
                         {
                             path: 'dashboard',
                             Component: Dashboard,
+                        },
+                        {
+                            path: 'systemHealth',
+                            Component: SystemHealth,
                         },
                         {
                             path: 'reports',

--- a/src/resources/js/components/UpgradeChecksList.js
+++ b/src/resources/js/components/UpgradeChecksList.js
@@ -1,0 +1,107 @@
+import {
+    Box,
+    Chip,
+    Link,
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    Typography,
+} from "@mui/material";
+import {
+    CheckCircle as CheckIcon,
+    Info as InfoIcon,
+    Warning as WarningIcon,
+    Error as ErrorIcon,
+    RemoveCircleOutline as SkipIcon,
+    OpenInNew as OpenInNewIcon,
+} from "@mui/icons-material";
+import { useLocalization } from "../contexts/LocalizationContext";
+
+function getCheckIcon(status) {
+    switch (status) {
+        case 'pass':
+            return <CheckIcon color="success" fontSize="small" />;
+        case 'warn':
+            return <WarningIcon color="warning" fontSize="small" />;
+        case 'fail':
+            return <ErrorIcon color="error" fontSize="small" />;
+        case 'skip':
+            return <SkipIcon color="disabled" fontSize="small" />;
+        default:
+            return <InfoIcon color="action" fontSize="small" />;
+    }
+}
+
+function statusChipColor(status) {
+    switch (status) {
+        case 'pass':
+            return 'success';
+        case 'warn':
+            return 'warning';
+        case 'fail':
+            return 'error';
+        case 'skip':
+            return 'default';
+        default:
+            return 'default';
+    }
+}
+
+export default function UpgradeChecksList({ checks = [], dense = true, showStatusChip = false }) {
+    const { getWord } = useLocalization();
+
+    if (!checks.length) {
+        return null;
+    }
+
+    return (
+        <List dense={dense} sx={{ pt: 0 }}>
+            {checks.map((check) => (
+                <ListItem key={check.id} disableGutters sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemIcon sx={{ minWidth: 32, mt: 0.25 }}>
+                        {getCheckIcon(check.status)}
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                                <Typography component="span" variant="body2" fontWeight={500}>
+                                    {check.label}
+                                </Typography>
+                                {showStatusChip && (
+                                    <Chip
+                                        label={check.status}
+                                        size="small"
+                                        color={statusChipColor(check.status)}
+                                        variant="outlined"
+                                    />
+                                )}
+                            </Box>
+                        }
+                        secondary={
+                            <>
+                                {check.message && (
+                                    <Typography component="span" variant="body2" color="text.secondary" display="block">
+                                        {check.message}
+                                    </Typography>
+                                )}
+                                {check.url && (
+                                    <Link
+                                        href={check.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        variant="body2"
+                                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}
+                                    >
+                                        {getWord('open_in_twilio_console') || 'Open in Twilio Console'}
+                                        <OpenInNewIcon sx={{ fontSize: 14 }} />
+                                    </Link>
+                                )}
+                            </>
+                        }
+                    />
+                </ListItem>
+            ))}
+        </List>
+    );
+}

--- a/src/resources/js/pages/Dashboard.js
+++ b/src/resources/js/pages/Dashboard.js
@@ -21,15 +21,9 @@ import {
     Info as InfoIcon,
     Warning as WarningIcon,
     Error as ErrorIcon,
-    RemoveCircleOutline as SkipIcon,
-    OpenInNew as OpenInNewIcon
 } from "@mui/icons-material";
-import Link from "@mui/material/Link";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import ListItemText from "@mui/material/ListItemText";
 import { useLocalization } from "../contexts/LocalizationContext";
+import UpgradeChecksList from "../components/UpgradeChecksList";
 
 function Dashboard() {
     const { getWord } = useLocalization();
@@ -41,21 +35,6 @@ function Dashboard() {
     const [systemStatus, setSystemStatus] = useState('checking');
     const [systemMessage, setSystemMessage] = useState('');
     const [systemChecks, setSystemChecks] = useState([]);
-
-    const getCheckIcon = (status) => {
-        switch (status) {
-            case 'pass':
-                return <CheckIcon color="success" fontSize="small" />;
-            case 'warn':
-                return <WarningIcon color="warning" fontSize="small" />;
-            case 'fail':
-                return <ErrorIcon color="error" fontSize="small" />;
-            case 'skip':
-                return <SkipIcon color="disabled" fontSize="small" />;
-            default:
-                return <InfoIcon color="action" fontSize="small" />;
-        }
-    };
 
     const getUser = async () => {
         apiClient.get('/api/v1/user', {
@@ -258,39 +237,7 @@ function Dashboard() {
                                         )}
                                     </Typography>
                                     {systemChecks.length > 0 && (
-                                        <List dense sx={{ mt: 1, pt: 0 }}>
-                                            {systemChecks.map((check) => (
-                                                <ListItem key={check.id} disableGutters sx={{ alignItems: 'flex-start', py: 0.5 }}>
-                                                    <ListItemIcon sx={{ minWidth: 32, mt: 0.25 }}>
-                                                        {getCheckIcon(check.status)}
-                                                    </ListItemIcon>
-                                                    <ListItemText
-                                                        primary={check.label}
-                                                        secondary={
-                                                            <>
-                                                                {check.message && (
-                                                                    <Typography component="span" variant="body2" color="text.secondary" display="block">
-                                                                        {check.message}
-                                                                    </Typography>
-                                                                )}
-                                                                {check.url && (
-                                                                    <Link
-                                                                        href={check.url}
-                                                                        target="_blank"
-                                                                        rel="noopener noreferrer"
-                                                                        variant="body2"
-                                                                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}
-                                                                    >
-                                                                        {getWord('open_in_twilio_console') || 'Open in Twilio Console'}
-                                                                        <OpenInNewIcon sx={{ fontSize: 14 }} />
-                                                                    </Link>
-                                                                )}
-                                                            </>
-                                                        }
-                                                    />
-                                                </ListItem>
-                                            ))}
-                                        </List>
+                                        <UpgradeChecksList checks={systemChecks} />
                                     )}
                                 </Box>
                             </Stack>

--- a/src/resources/js/pages/SystemHealth.js
+++ b/src/resources/js/pages/SystemHealth.js
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Stack,
+    Typography,
+} from "@mui/material";
+import {
+    CheckCircle as CheckIcon,
+    Error as ErrorIcon,
+    Refresh as RefreshIcon,
+    Warning as WarningIcon,
+} from "@mui/icons-material";
+import apiClient from "../services/api";
+import UpgradeChecksList from "../components/UpgradeChecksList";
+import { useLocalization } from "../contexts/LocalizationContext";
+
+function deriveStatus(responseData, checks) {
+    const hasFail = checks.some((check) => check.status === 'fail');
+    const hasWarn = checks.some((check) => check.status === 'warn');
+
+    if (responseData?.status === false || hasFail) {
+        return 'error';
+    }
+    if (responseData?.warnings || hasWarn) {
+        return 'warning';
+    }
+    if (responseData?.status === true) {
+        return 'healthy';
+    }
+    return 'unknown';
+}
+
+export default function SystemHealth() {
+    const { getWord } = useLocalization();
+    const [loading, setLoading] = useState(true);
+    const [systemStatus, setSystemStatus] = useState('checking');
+    const [systemMessage, setSystemMessage] = useState('');
+    const [systemChecks, setSystemChecks] = useState([]);
+
+    const loadUpgradeAdvisor = useCallback(async () => {
+        setLoading(true);
+        try {
+            const response = await apiClient.get('/api/v1/upgrade');
+            if (response.data) {
+                const checks = Array.isArray(response.data.checks) ? response.data.checks : [];
+                setSystemChecks(checks);
+                setSystemStatus(deriveStatus(response.data, checks));
+                setSystemMessage(
+                    response.data.warnings
+                    || response.data.message
+                    || ''
+                );
+            }
+        } catch (error) {
+            console.error('Error fetching upgrade advisor status:', error);
+            setSystemStatus('error');
+            setSystemMessage('');
+            setSystemChecks([]);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadUpgradeAdvisor();
+    }, [loadUpgradeAdvisor]);
+
+    const statusIcon = {
+        healthy: <CheckIcon color="success" />,
+        warning: <WarningIcon color="warning" />,
+        error: <ErrorIcon color="error" />,
+    }[systemStatus];
+
+    const statusChip = {
+        healthy: { label: getWord('healthy') || 'Healthy', color: 'success' },
+        warning: { label: getWord('warning') || 'Warning', color: 'warning' },
+        error: { label: getWord('error') || 'Error', color: 'error' },
+    }[systemStatus];
+
+    return (
+        <Box sx={{ p: 3 }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 3 }}>
+                <Box>
+                    <Typography variant="h4" fontWeight="bold" gutterBottom>
+                        {getWord('system_health') || 'System Health'}
+                    </Typography>
+                    <Typography variant="body1" color="text.secondary">
+                        {getWord('system_health_description')
+                            || 'Upgrade advisor checks for configuration, database, Twilio, and PHP requirements.'}
+                    </Typography>
+                </Box>
+                <Button
+                    variant="outlined"
+                    startIcon={loading ? <CircularProgress size={16} /> : <RefreshIcon />}
+                    onClick={loadUpgradeAdvisor}
+                    disabled={loading}
+                >
+                    {getWord('refresh') || 'Refresh'}
+                </Button>
+            </Stack>
+
+            <Card sx={{ mb: 3 }}>
+                <CardContent>
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+                        {statusIcon}
+                        <Typography variant="h6" fontWeight="600">
+                            {getWord('upgrade_advisor') || 'Upgrade Advisor'}
+                        </Typography>
+                        {statusChip && (
+                            <Chip label={statusChip.label} color={statusChip.color} size="small" />
+                        )}
+                    </Stack>
+
+                    {systemMessage && (
+                        <Alert
+                            severity={systemStatus === 'healthy' ? 'success' : systemStatus === 'warning' ? 'warning' : 'error'}
+                            sx={{ mb: 2 }}
+                        >
+                            {systemMessage}
+                        </Alert>
+                    )}
+
+                    {loading && systemChecks.length === 0 ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                            <CircularProgress />
+                        </Box>
+                    ) : (
+                        <UpgradeChecksList checks={systemChecks} showStatusChip />
+                    )}
+                </CardContent>
+            </Card>
+
+            <Typography variant="body2" color="text.secondary">
+                {getWord('upgrade_advisor_api_hint') || 'You can also open'}{' '}
+                <a href="/api/v1/upgrade" target="_blank" rel="noopener noreferrer">
+                    /api/v1/upgrade
+                </a>{' '}
+                {getWord('upgrade_advisor_api_hint_suffix') || 'in a browser for the raw JSON response (no login required).'}
+            </Typography>
+        </Box>
+    );
+}

--- a/src/resources/views/admin/pending-destructive-migrations.blade.php
+++ b/src/resources/views/admin/pending-destructive-migrations.blade.php
@@ -35,14 +35,8 @@
             font-family: monospace;
             margin: 0.5rem 0;
         }
-        .command {
-            background: #e9ecef;
-            padding: 1rem;
-            border-radius: 4px;
-            font-family: monospace;
-            margin: 1rem 0;
-        }
         code { background: #e9ecef; padding: 0.2rem 0.4rem; border-radius: 3px; }
+        a { color: #1565c0; }
     </style>
 </head>
 <body>
@@ -60,11 +54,23 @@
             <li><?php echo htmlspecialchars($migration); ?></li>
         <?php endforeach; ?>
     </ul>
-    <p>Run the following command from a shell on the server:</p>
-    <div class="command">php artisan migrate</div>
+    <p>
+        <strong>What to do next:</strong> Contact your server administrator or hosting
+        provider and ask them to apply the pending database migration during a
+        maintenance window. Most Yap operators on shared hosting do not have shell
+        access — your host's support team or whoever manages the server can run the
+        migration for you.
+    </p>
     <p>
         After the migration completes successfully, reload this page. If the migration
-        fails, consult the <code>users_pre_uuid_backup</code> table for recovery data.
+        fails, consult the <code>users_pre_uuid_backup</code> table for recovery data
+        and restore from your own backup if needed.
+    </p>
+    <p>
+        For other configuration checks (PHP extensions, Twilio, database shape), open
+        <a href="/api/v1/upgrade">/api/v1/upgrade</a> once the site is reachable, or
+        see the
+        <a href="https://yap.bmlt.app/miscellaneous/upgrading-from-yap-4x-to-yap-5x">4.x → 5.x upgrade guide</a>.
     </p>
 </div>
 </body>

--- a/src/tests/Feature/DatabaseMigrationsTest.php
+++ b/src/tests/Feature/DatabaseMigrationsTest.php
@@ -13,7 +13,7 @@ test('returns maintenance page when destructive migrations are pending', functio
     $response
         ->assertStatus(503)
         ->assertSee('Database Upgrade Required')
-        ->assertSee('php artisan migrate')
+        ->assertSee('server administrator')
         ->assertSee(DB_UUID_MIGRATION);
 });
 


### PR DESCRIPTION
Closes #1617

## Summary
- Scrub operator-facing docs (`src/docs/`, `RELEASENOTES.md`, setup guide) of `php artisan` / `yap:preflight` instructions; point admins to `GET /api/v1/upgrade`, **Dashboard**, and the new **System Health** page.
- Update the HTTP 503 "Database Upgrade Required" page to guide operators without shell access to involve their server administrator.
- Add **System Health** admin SPA page with full upgrade advisor `checks` list and refresh control; extract shared `UpgradeChecksList` component used by Dashboard.
- Document `yap:preflight` for developers only in `CONTRIBUTE.md`.

## Test plan
- [ ] Open `/admin/systemHealth` after login and confirm all upgrade advisor checks render with pass/warn/fail status.
- [ ] Confirm Dashboard still shows the checks list summary.
- [ ] Visit `/api/v1/upgrade` unauthenticated and confirm JSON still works.
- [ ] Trigger pending destructive migration state and confirm 503 page shows server-admin guidance (no `php artisan migrate`).
- [ ] Spot-check updated upgrade docs on yap.bmlt.app after deploy.


Made with [Cursor](https://cursor.com)