### PR TITLE
fix: validate Twilio signature against the raw request URI (#1573)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ### 4.5.2 (UNRELEASED)
+* Fixed Twilio webhook signature validation rejecting every request whose URL carries a query string, which broke the IVR past the first prompt (`input-method.php`, `status.php`, and the helpline dialer callbacks all returned 403 "Forbidden"). The signature is now checked against the raw request URI instead of Laravel's normalized `fullUrl()`, which re-sorted the query parameters and re-encoded spaces. [#1573]
 * Added an authenticated media proxy so voicemail recording links in notification emails, SMS, and the admin portal keep working now that Twilio enforces HTTP Basic Auth on media URLs. Links are served through a signed YAP endpoint that streams the recording using the account credentials server-side. [#1573]
 * Enforce Twilio webhook signature validation on all inbound routes (IVR call flow, SMS gateway, voicemail, dialback, helpline routing, status callbacks, TwiML readings) so spoofed requests are rejected. [#1569]
 

--- a/src/app/Http/Middleware/ValidateTwilioSignature.php
+++ b/src/app/Http/Middleware/ValidateTwilioSignature.php
@@ -56,23 +56,60 @@ class ValidateTwilioSignature
         $validator = new RequestValidator($authToken);
         $signature = $request->header('X-Twilio-Signature', '');
 
-        // Validate against the URL the framework resolved (honoring the trusted
-        // proxy configuration in TrustProxies), never raw client-supplied
-        // forwarding headers.
-        $url = $request->fullUrl();
-
         // Twilio signs POST requests using the POST body params only; for GET the
         // query string is already part of the URL.
         $params = $request->isMethod('POST') ? $request->post() : [];
 
-        if (!$validator->validate($signature, $url, $params)) {
-            Log::warning('Invalid Twilio signature rejected', [
-                'url' => $url,
-                'ip' => $request->ip(),
-            ]);
-            return response('Forbidden', 403);
+        $urls = $this->candidateUrls($request);
+
+        foreach ($urls as $url) {
+            if ($validator->validate($signature, $url, $params)) {
+                return $next($request);
+            }
         }
 
-        return $next($request);
+        Log::warning('Invalid Twilio signature rejected', [
+            'method' => $request->method(),
+            'urls' => $urls,
+            'has_signature' => $signature !== '',
+            'ip' => $request->ip(),
+        ]);
+        return response('Forbidden', 403);
+    }
+
+    /**
+     * The URLs to validate the signature against, most faithful first.
+     *
+     * Twilio computes its signature over the exact URL it requested, so the
+     * query string has to be compared byte for byte. $request->fullUrl() cannot
+     * do that: it rebuilds the query string through Symfony's
+     * normalizeQueryString(), which sorts the parameters alphabetically and
+     * re-encodes them as RFC 3986 (a space becomes %20 rather than +). Every
+     * webhook URL that carries a query string — each Gather action and status
+     * callback in the IVR — therefore hashed differently than Twilio signed it
+     * and was rejected with a 403 (#1573).
+     *
+     * getRequestUri() is the raw, unmodified request target, so pairing it with
+     * the resolved scheme and host (honoring TrustProxies, never raw
+     * client-supplied forwarding headers) reproduces the signed URL exactly.
+     *
+     * @param Request $request
+     * @return string[]
+     */
+    protected function candidateUrls(Request $request): array
+    {
+        $urls = [$request->getSchemeAndHttpHost() . $request->getRequestUri()];
+
+        // Kept as a fallback for deployments where a rewrite leaves REQUEST_URI
+        // as something other than the URL Twilio called, and for the trailing
+        // slash fullUrl() strips. Trying a second server-derived URL does not
+        // weaken the check: a forged request still has to produce a valid HMAC
+        // over one of them, which is impossible without the auth token.
+        $fullUrl = $request->fullUrl();
+        if (!in_array($fullUrl, $urls, true)) {
+            $urls[] = $fullUrl;
+        }
+
+        return $urls;
     }
 }

--- a/src/tests/Feature/TwilioSignatureValidationTest.php
+++ b/src/tests/Feature/TwilioSignatureValidationTest.php
@@ -43,7 +43,7 @@ test('fails closed when no auth token is configured', function ($method) {
 test('allows a genuinely signed Twilio request', function ($method) {
     $_SESSION["override_twilio_auth_token"] = "testtoken";
 
-    // The middleware validates against $request->fullUrl(); in the test harness
+    // The middleware validates against the request URL; in the test harness
     // (no forwarded headers) that is http://localhost for "/", with no params.
     $signature = (new RequestValidator("testtoken"))->computeSignature('http://localhost', []);
 
@@ -104,6 +104,66 @@ test('allows a genuinely signed Twilio POST that carries body params', function 
     $response = $this->call('POST', '/', $params, [], [], ['HTTP_X_TWILIO_SIGNATURE' => $signature]);
 
     $response->assertStatus(200);
+});
+
+// Regression coverage for #1573: every Gather action and status callback in the
+// IVR is a URL with a query string, and Twilio signs those bytes exactly as it
+// sends them. Validating against $request->fullUrl() re-sorted the parameters
+// alphabetically and re-encoded "+" as "%20", so the computed HMAC never matched
+// and the whole call flow past the first prompt 403'd.
+test('allows a genuinely signed GET whose query string is not normalized', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    // Parameters in Twilio's order (action-URL params first, then Twilio's own)
+    // rather than alphabetical, and a space encoded as "+" — both of which
+    // fullUrl() rewrites.
+    $query = 'Retry=1&RetryMessage=Couldn%27t+find+that+location.&Digits=2&AccountSid=AC00000000000000000000000000000000';
+    $url = 'http://localhost/input-method.php?' . $query;
+
+    $signature = (new RequestValidator("testtoken"))->computeSignature($url, []);
+
+    $response = $this->call('GET', '/input-method.php?' . $query, [], [], [], [
+        'HTTP_X_TWILIO_SIGNATURE' => $signature,
+    ]);
+
+    $response->assertStatus(200);
+});
+
+test('allows a genuinely signed POST to a URL that carries a query string', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    // Twilio signs the full URL (query string included) concatenated with the
+    // sorted POST body params, so both halves have to be reproduced verbatim.
+    $query = 'SearchType=1&Retry=1';
+    $url = 'http://localhost/input-method.php?' . $query;
+    $params = [
+        'Digits' => '2',
+        'From' => '+15555550123',
+        'To' => '+15555550100',
+    ];
+
+    $signature = (new RequestValidator("testtoken"))->computeSignature($url, $params);
+
+    $response = $this->call('POST', '/input-method.php?' . $query, $params, [], [], [
+        'HTTP_X_TWILIO_SIGNATURE' => $signature,
+    ]);
+
+    $response->assertStatus(200);
+});
+
+test('rejects a request signed for a different URL', function () {
+    $_SESSION["override_twilio_auth_token"] = "testtoken";
+
+    // The signature is valid, but for another path — accepting more than one
+    // candidate URL must not turn into accepting any URL.
+    $signature = (new RequestValidator("testtoken"))
+        ->computeSignature('http://localhost/somewhere-else.php?Digits=2', []);
+
+    $response = $this->call('GET', '/input-method.php?Digits=2', [], [], [], [
+        'HTTP_X_TWILIO_SIGNATURE' => $signature,
+    ]);
+
+    $response->assertStatus(403);
 });
 
 test('dev bypass skips validation for unsigned requests in non-production', function ($method) {


### PR DESCRIPTION
Fixes the 403 / `Invalid Twilio signature rejected` regression Michigan NA hit while testing the media-proxy build, reported in #1573.

## The bug

Every Twilio webhook whose URL carries a **query string** was rejected with `403 Forbidden`. That breaks the IVR immediately past the first prompt:

- `/index.php` (the incoming-call webhook) has no query string, so it validated — the caller heard the menu.
- The `<Gather>` action it returns (`input-method.php?...`), the status callback (`status.php?...`), and the helpline dialer callbacks all carry query strings, so pressing **1** or **2** 403'd and Twilio played *"an application error has occurred"* and hung up.

`ValidateTwilioSignature` (added in #1569) hashed `$request->fullUrl()`. That is **not** the URL Twilio signed. `fullUrl()` rebuilds the query string through Symfony's `normalizeQueryString()`, which `ksort`s the parameters and re-encodes them as RFC 3986. Twilio appends its own parameters *after* the action URL's (so, not alphabetical) and form-encodes spaces as `+`, so both the order and the bytes differ:

```
signed by Twilio  ...?Digits=1&Retry=1&RetryMessage=Couldn%27t+find+an+address+for+that+location.&AccountSid=...
hashed by yap     ...?AccountSid=...&Digits=1&Retry=1&RetryMessage=Couldn%27t%20find%20an%20address%20for%20that%20location.
```

Different string in, different HMAC out, 403.

## The fix

Validate against `getSchemeAndHttpHost() . getRequestUri()`. `getRequestUri()` is the raw, unmodified request target, so it reproduces the signed URL byte for byte.

`fullUrl()` is kept as a **second** candidate so that deployments working today (including the trailing slash `fullUrl()` strips) can't regress. Trying another server-derived URL does not weaken the check — forging either still requires the auth token, and it's the same thing the Twilio SDK already does internally for the with/without-port variants.

The rejection log now also records the request method, both candidate URLs, and whether a signature header was present, so the next field report is diagnosable from `laravel.log` alone.

## Verification

Reproduced directly against the vendored `Twilio\Security\RequestValidator`, signing the exact URL shape a `<Gather method="GET">` callback produces:

| case | old (`fullUrl()`) | new (raw request URI) |
|---|---|---|
| GET with query string | ❌ invalid | ✅ valid |
| POST with query string + body params | ❌ invalid | ✅ valid |
| POST, no query string (`/index.php`) | ✅ valid | ✅ valid |

That last row is why the reporter's first prompt worked and everything after it didn't.

Three tests added to `TwilioSignatureValidationTest`:

- a signed GET whose query string is unsorted and `+`-encoded → 200
- a signed POST to a URL carrying a query string → 200
- a signature valid for a *different* URL → still 403 (accepting more than one candidate must not become accepting any URL)

Both 200 cases fail with 403 against the previous implementation, so they pin the regression.

`TwilioSignatureValidationTest` is green (16/16) and `phpcs` is clean. The full suite shows 459 passed / 24 failed, and those 24 are identical on a clean `4.5.x` checkout — they're the tests needing `GOOGLE_MAPS_API_KEY` and live Twilio/network access, which aren't available locally.

Closes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)