### PR TITLE
Fix helpline dialer conference lookup retries so callers are not stranded

### DIFF
--- a/src/app/Constants/ConferenceSpecial.php
+++ b/src/app/Constants/ConferenceSpecial.php
@@ -5,4 +5,6 @@ namespace App\Constants;
 class ConferenceSpecial
 {
     const EVENTUAL_CONSISTENCY_RETRIES = 20;
+
+    const EVENTUAL_CONSISTENCY_RETRY_DELAY_MICROSECONDS = 500000;
 }

--- a/src/app/Http/Controllers/HelplineController.php
+++ b/src/app/Http/Controllers/HelplineController.php
@@ -26,6 +26,7 @@ use App\Structures\VolunteerRoutingParameters;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 use Twilio\Exceptions\TwilioException;
 use Twilio\TwiML\VoiceResponse;
 
@@ -269,12 +270,19 @@ class HelplineController extends Controller
         // Sometime in August 2023, Twilio introduced a change in API Behavior. The conferences API
         // now seems to be eventually consistent. Sometimes we get the conference back on the first
         // try, and other times it takes a few tries. Retrying every half second seems to get the
-        // job done after no more than about 4 retries in the worst case. We try up to 10 times just
-        // to be safe.
+        // job done after no more than about 4 retries in the worst case. We try up to 20 times just
+        // to be safe. PHP's sleep() truncates floats, so the delay must be usleep(500000). Transient
+        // list errors are treated like an empty result so they cannot 500 the webhook mid-call.
+        $conferences = [];
         for ($i = 0; $i < ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRIES; $i++) {
-            $conferences = $this->twilio->client()
-                ->conferences
-                ->read(array("friendlyName" => $request->get('FriendlyName'), "status" => "in-progress"));
+            try {
+                $conferences = $this->twilio->client()
+                    ->conferences
+                    ->read(array("friendlyName" => $request->get('FriendlyName'), "status" => "in-progress"));
+            } catch (TwilioException $e) {
+                Log::warning("conferences list failed, retry $i: " . $e->getMessage());
+                $conferences = [];
+            }
 
             if ($i > 0) {
                 Log::debug("conferences eventual consistency issue, retry $i");
@@ -284,7 +292,7 @@ class HelplineController extends Controller
                 break;
             }
 
-            sleep(0.5);
+            Sleep::usleep(ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRY_DELAY_MICROSECONDS);
         }
 
         if (count($conferences) > 0) {

--- a/src/tests/Feature/HelplineDialerTest.php
+++ b/src/tests/Feature/HelplineDialerTest.php
@@ -15,6 +15,7 @@ use App\Services\TwilioService;
 use App\Structures\ServiceBodyCallHandling;
 use App\Structures\VolunteerData;
 use Tests\FakeTwilioHttpClient;
+use Twilio\Exceptions\RestException;
 
 beforeAll(function () {
     putenv("ENVIRONMENT=test");
@@ -1059,6 +1060,39 @@ test('volunteer leave the call', function ($method) {
         'FriendlyName' => $this->conferenceName,
         'StatusCallbackEvent' => 'participant-leave',
         'SequenceNumber' => 2
+    ]);
+    $response
+        ->assertStatus(200)
+        ->assertHeader("Content-Type", "application/json");
+})->with(['GET', 'POST']);
+
+test('conference list RestException does not 500 the helpline dialer', function ($method) {
+    $serviceBodyCallHandlingData = new ServiceBodyCallHandling();
+    $serviceBodyCallHandlingData->volunteer_routing = VolunteerRoutingType::VOLUNTEERS;
+    $serviceBodyCallHandlingData->service_body_id = $this->serviceBodyId;
+    $serviceBodyCallHandlingData->volunteer_routing_enabled = true;
+    $serviceBodyCallHandlingData->call_strategy = CycleAlgorithm::LINEAR_CYCLE_AND_VOICEMAIL;
+
+    ConfigData::createServiceBodyCallHandling(
+        $this->serviceBodyId,
+        $serviceBodyCallHandlingData
+    );
+
+    $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
+    $conferenceListMock->shouldReceive("read")
+        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
+        ->andThrow(new RestException('[HTTP 502] Unable to fetch page', 502, 502))
+        ->times(ConferenceSpecial::EVENTUAL_CONSISTENCY_RETRIES);
+    $this->twilioClient->conferences = $conferenceListMock;
+
+    $response = $this->call($method, '/helpline-dialer.php', [
+        'CallSid'=>$this->callSid,
+        'SearchType' => "1",
+        'Called' => "+12125551212",
+        'Caller' => $this->caller,
+        'FriendlyName' => $this->conferenceName,
+        'StatusCallbackEvent' => 'participant-join',
+        'SequenceNumber' => 1
     ]);
     $response
         ->assertStatus(200)

--- a/src/tests/Pest.php
+++ b/src/tests/Pest.php
@@ -3,6 +3,7 @@
 use App\Services\SettingsService;
 use App\Services\TwilioService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Sleep;
 use Tests\FakeTwilioHttpClient;
 use Tests\TestCase;
 use Tests\TwilioTestUtility;
@@ -11,7 +12,12 @@ uses(TestCase::class, RefreshDatabase::class)
     ->beforeEach(function () {
         env("ENVIRONMENT", "test");
         $_COOKIE["PHPSESSID"] = "fake";
+        // HelplineController::dial() waits 500ms between conference-list retries.
+        Sleep::fake();
         $this->artisan('migrate:fresh');
+    })
+    ->afterEach(function () {
+        Sleep::fake(false);
     })
     ->in('Feature');
 


### PR DESCRIPTION
Closes #1630

## Summary
- Pace `HelplineController::dial()` conference lookups at 500ms (`Sleep::usleep`) instead of `sleep(0.5)`, which PHP truncated to a no-op burst of API calls.
- Catch transient Twilio list errors (`TwilioException`) as empty results so a 502 cannot 500 the `/helpline-dialer` webhook mid-call.

## Test plan
- [ ] Helpline volunteer progression still dials the next volunteer after no-answer / reject
- [ ] A transient conference-list failure is retried and does not play Twilio's "an application error has occurred"
- [ ] Exhausted lookup retries still return 200 JSON instead of 500


Made with [Cursor](https://cursor.com)