### PR TITLE
Skip conference lookup for helpline cleanup callbacks (4.5.x)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### 4.5.3
+* Skip conference lookup on helpline cleanup callbacks. `HelplineController::dial()` no longer retries Twilio conference reads for status callbacks that never consume the result (empty `CallStatus`, SequenceNumber 2/3). Those lookups always exhausted the retry budget after the conference had already ended, holding PHP workers long enough to time out caller-facing webhooks such as voicemail TwiML. Lookup retries are also capped at 8 (worst case observed is ~4). [#1634]
+
 ### 4.5.2 (August 15, 2026)
 * Fixed Twilio webhook signature validation rejecting every request whose URL carries a query string, which broke the IVR past the first prompt (`input-method.php`, `status.php`, and the helpline dialer callbacks all returned 403 "Forbidden"). The signature is now checked against the raw request URI instead of Laravel's normalized `fullUrl()`, which re-sorted the query parameters and re-encoded spaces. [#1573]
 * Added an authenticated media proxy so voicemail recording links in notification emails, SMS, and the admin portal keep working now that Twilio enforces HTTP Basic Auth on media URLs. Links are served through a signed YAP endpoint that streams the recording using the account credentials server-side. [#1573]

--- a/src/app/Constants/ConferenceSpecial.php
+++ b/src/app/Constants/ConferenceSpecial.php
@@ -4,7 +4,7 @@ namespace App\Constants;
 
 class ConferenceSpecial
 {
-    const EVENTUAL_CONSISTENCY_RETRIES = 20;
+    const EVENTUAL_CONSISTENCY_RETRIES = 8;
 
     const EVENTUAL_CONSISTENCY_RETRY_DELAY_MICROSECONDS = 500000;
 }

--- a/src/app/Http/Controllers/HelplineController.php
+++ b/src/app/Http/Controllers/HelplineController.php
@@ -267,10 +267,26 @@ class HelplineController extends Controller
                 ->header("Content-Type", "application/json");
         }
 
+        // Only volunteer-progression and participant-leave consume $conferences.
+        // Post-call cleanup callbacks (empty CallStatus, SequenceNumber 2/3) never
+        // match those branches, and their conference has already ended, so the
+        // lookup would exhaust every retry and hold a PHP worker for no reason.
+        $needsConference = ($request->has('SequenceNumber') && intval($request->get('SequenceNumber')) == 1)
+            || ($request->has('CallStatus') &&
+                ($request->get('CallStatus') == TwilioCallStatus::NOANSWER
+                    || $request->get('CallStatus') == TwilioCallStatus::COMPLETED
+                    || $request->get('CallStatus') == TwilioCallStatus::FAILED
+                    || $request->get('CallStatus') == TwilioCallStatus::BUSY))
+            || ($request->has('StatusCallbackEvent') && $request->get('StatusCallbackEvent') == 'participant-leave');
+
+        if (!$needsConference) {
+            return response([])->header("Content-Type", "application/json");
+        }
+
         // Sometime in August 2023, Twilio introduced a change in API Behavior. The conferences API
         // now seems to be eventually consistent. Sometimes we get the conference back on the first
         // try, and other times it takes a few tries. Retrying every half second seems to get the
-        // job done after no more than about 4 retries in the worst case. We try up to 20 times just
+        // job done after no more than about 4 retries in the worst case. We try up to 8 times just
         // to be safe. PHP's sleep() truncates floats, so the delay must be usleep(500000). Transient
         // list errors are treated like an empty result so they cannot 500 the webhook mid-call.
         $conferences = [];

--- a/src/tests/Feature/HelplineDialerTest.php
+++ b/src/tests/Feature/HelplineDialerTest.php
@@ -155,13 +155,10 @@ test('do nothing', function ($method) {
         $serviceBodyCallHandlingData
     );
 
+    // No SequenceNumber, CallStatus, or participant-leave — this callback
+    // cannot consume $conferences, so the lookup must be skipped.
     $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
-    $conferenceListMock->shouldReceive("read")
-        ->with(['friendlyName' => $this->conferenceName, 'status' => 'in-progress'])
-        ->andReturn(json_decode(
-            '[{"status":"in-progress","sid":"'.$this->conferenceName.'"}]'
-        ))
-        ->once();
+    $conferenceListMock->shouldReceive("read")->never();
     $this->twilioClient->conferences = $conferenceListMock;
 
     $response = $this->call($method, '/helpline-dialer.php', [
@@ -1065,6 +1062,25 @@ test('volunteer leave the call', function ($method) {
         ->assertStatus(200)
         ->assertHeader("Content-Type", "application/json");
 })->with(['GET', 'POST']);
+
+test('post-call cleanup callbacks skip conference lookup', function ($method, $sequenceNumber, $statusCallbackEvent) {
+    $_SESSION['override_service_body_id'] = $this->serviceBodyId;
+
+    $conferenceListMock = mock("\Twilio\Rest\Api\V2010\Account\ConferenceList");
+    $conferenceListMock->shouldReceive("read")->never();
+    $this->twilioClient->conferences = $conferenceListMock;
+
+    $response = $this->call($method, '/helpline-dialer.php', [
+        'CallSid' => $this->callSid,
+        'FriendlyName' => $this->conferenceName,
+        'StatusCallbackEvent' => $statusCallbackEvent,
+        'SequenceNumber' => $sequenceNumber,
+        'CallStatus' => '',
+    ]);
+    $response
+        ->assertStatus(200)
+        ->assertHeader("Content-Type", "application/json");
+})->with(['GET', 'POST'], [2, 3], ['conference-end', 'participant-join']);
 
 test('conference list RestException does not 500 the helpline dialer', function ($method) {
     $serviceBodyCallHandlingData = new ServiceBodyCallHandling();


### PR DESCRIPTION
Closes #1634

## Summary
- Backport of #1633 onto `4.5.x`: skip the Twilio conference-lookup retry loop in `HelplineController::dial()` for status callbacks that never consume `$conferences` (empty `CallStatus`, SequenceNumber 2/3, non-leave events).
- Cap `EVENTUAL_CONSISTENCY_RETRIES` at 8 (observed worst case is ~4) so volunteer-progression lookups that miss a conference cannot hold a PHP worker for 20 attempts.

## Test plan
- [x] HelplineDialerTest: cleanup callbacks (`conference-end` / later `participant-join`, SequenceNumber 2/3) never call `conferences->read()`
- [x] HelplineDialerTest: "do nothing" requests without SequenceNumber/CallStatus/leave also skip the lookup
- [x] Existing volunteer-progression, participant-leave, and eventual-consistency retry tests still pass


Made with [Cursor](https://cursor.com)